### PR TITLE
BSCBridgeV2 burn-to-dead-wallet flow + verifier/bridge refinements and comprehensive tests

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,11 @@ src = "src"
 out = "out"
 libs = ["lib"]
 optimizer = true
+optimizer_runs = 162
+
+
+[profile.v2]
+optimizer = true
 optimizer_runs = 1
 
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib"]
 optimizer = true
-optimizer_runs = 162
+optimizer_runs = 1
 
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/src/BSCBridgeV2.sol
+++ b/src/BSCBridgeV2.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {BaseBridge} from "./BaseBridge.sol";
+import {IBridgeRegistry} from "./interface/IBridgeRegistry.sol";
+
+import {Const} from "./lib/Const.sol";
+import {ICrossMintableERC20} from "./token/ICrossMintableERC20.sol";
+
+/**
+ * @title BSCBridgeV2
+ * @notice BSC-side bridge contract for cross-chain token transfers
+ * @dev Extends BaseBridge to handle BSC-specific bridge operations
+ * - Handles token transfers between BSC and Cross chain
+ * - Manages CROSS token pair registration and initial supply
+ */
+contract BSCBridgeV2 is BaseBridge {
+    using SafeERC20 for IERC20;
+
+    error BSCBridgeCanNotZeroAddress();
+    error BSCBridgeCanNotZero();
+    error BSCBridgeInvalidDeadWallet();
+
+    uint private crossChainID;
+    IERC20 private cross;
+
+    mapping(address => bool) private deadWallets;
+
+    /// @dev Storage gap for future upgrades
+    uint[47] private __gap;
+
+    /**
+     * @notice Reinitializes the BSCBridge contract
+     * @param crossChainID_ Cross chain ID (e.g., 612055 for Cross chain, or other chain IDs)
+     * @param cross_ Address of the CROSS ERC20 token on this chain
+     */
+    function reinitializeBSCBridge(uint crossChainID_, IERC20 cross_)
+        external
+        onlyRole(Const.ADMIN_ROLE)
+        reinitializer(2)
+    {
+        require(crossChainID_ != 0, BSCBridgeCanNotZero());
+        require(address(cross_) != address(0), BSCBridgeCanNotZeroAddress());
+
+        crossChainID = crossChainID_;
+        cross = cross_;
+
+        deadWallets[address(0x000000000000000000000000000000000000dEaD)] = true;
+        deadWallets[address(0xdeaDDeADDEaDdeaDdEAddEADDEAdDeadDEADDEaD)] = true;
+        deadWallets[address(0xdEad000000000000000000000000000000000000)] = true;
+    }
+
+    /**
+     * @notice Burn CROSS tokens by sending them to a dead wallet
+     * @dev Emits BridgeInitiated to coordinate a cross-chain burn.
+     * Semantics of `alreadyTransferred`:
+     * - When `alreadyTransferred == true`:
+     *   - Caller MUST have ADMIN role.
+     *   - No token transfer occurs on this chain.
+     *   - Emitted BridgeInitiated uses `from = address(this)`.
+     * - When `alreadyTransferred == false`:
+     *   - No special role required.
+     *   - Transfers caller's CROSS tokens to `deadWallet` on this chain.
+     *   - Emitted BridgeInitiated uses `from = _msgSender()`.
+     * @param deadWallet The address of the dead wallet
+     * @param amount The amount of CROSS tokens to burn on the cross chain
+     * @param alreadyTransferred Whether tokens were already transferred to the dead wallet on this chain
+     */
+    function burnCrossToDeadWallet(address deadWallet, uint amount, bool alreadyTransferred)
+        external
+        whenNotPaused
+        nonReentrant
+    {
+        require(deadWallets[deadWallet], BSCBridgeInvalidDeadWallet());
+        require(amount > 0, BSCBridgeCanNotZero());
+
+        address from;
+        if (!alreadyTransferred) {
+            cross.safeTransferFrom(_msgSender(), deadWallet, amount);
+            from = _msgSender();
+        } else {
+            _checkRole(Const.ADMIN_ROLE, _msgSender());
+            from = address(this);
+        }
+
+        uint index = _useInitiateIndex(crossChainID);
+        emit BridgeInitiated(
+            crossChainID,
+            index,
+            IERC20(cross),
+            IERC20(Const.NATIVE_TOKEN),
+            from,
+            deadWallet,
+            amount,
+            0,
+            0,
+            "",
+            block.timestamp
+        );
+    }
+}

--- a/src/BSCBridgeV2.sol
+++ b/src/BSCBridgeV2.sol
@@ -74,6 +74,7 @@ contract BSCBridgeV2 is BaseBridge {
         external
         whenNotPaused
         nonReentrant
+        returns (bool)
     {
         require(deadWallets[deadWallet], BSCBridgeInvalidDeadWallet());
         require(amount > 0, BSCBridgeCanNotZero());
@@ -101,5 +102,7 @@ contract BSCBridgeV2 is BaseBridge {
             "",
             block.timestamp
         );
+
+        return true;
     }
 }

--- a/src/BaseBridge.sol
+++ b/src/BaseBridge.sol
@@ -594,7 +594,10 @@ contract BaseBridge is
 
         uint minimumValue;
         (minimumValue, _networkFee, _exFee) = bridgeVerifier.calculateFee(remoteChainID, token, value);
-        require(value >= minimumValue && networkFee >= _networkFee && exFee >= _exFee, BaseBridgeInvalidAmount());
+        require(
+            value != 0 && value >= minimumValue && networkFee >= _networkFee && exFee >= _exFee,
+            BaseBridgeInvalidAmount()
+        );
     }
 
     /**

--- a/src/BridgeVerifier.sol
+++ b/src/BridgeVerifier.sol
@@ -165,22 +165,18 @@ contract BridgeVerifier is AccessControl, IBridgeVerifier {
         if (score > type(uint192).max) return Const.FinalizeStatus.TokenScoreOverflow;
 
         if (_verificationAmountThreshold != 0 && _verificationAmountThreshold < score) {
-            status = Const.FinalizeStatus.VerificationAmountThresholdExceeded;
-        } else {
-            status = Const.FinalizeStatus.Success;
+            return Const.FinalizeStatus.VerificationAmountThresholdExceeded;
         }
 
-        if (_timeWindow == 0 || _periodTotalValueThreshold == 0) {
-            return status;
-        } else {
-            // Check for potential overflow before adding new score to the current volume
-            if (type(uint192).max - score < _tokenCurrentVolume[token]) {
-                return Const.FinalizeStatus.TokenCurrentVolumeOverflow;
-            }
+        if (_timeWindow == 0 || _periodTotalValueThreshold == 0) return Const.FinalizeStatus.Success;
 
-            // Update current token volume
-            _tokenCurrentVolume[token] += score;
+        // Check for potential overflow before adding new score to the current volume
+        if (type(uint192).max - score < _tokenCurrentVolume[token]) {
+            return Const.FinalizeStatus.TokenCurrentVolumeOverflow;
         }
+
+        // Update current token volume
+        _tokenCurrentVolume[token] += score;
 
         // Manage history and verify thresholds
         DoubleEndedQueue.Bytes32Deque storage deque = _tokenMovementHistory[token];
@@ -216,11 +212,11 @@ contract BridgeVerifier is AccessControl, IBridgeVerifier {
         bytes32 packedMovement = bytes32((currentTime << 192) | score);
         deque.pushBack(packedMovement);
 
-        if (status == Const.FinalizeStatus.Success && _tokenCurrentVolume[token] > _periodTotalValueThreshold) {
-            status = Const.FinalizeStatus.PeriodTotalValueThresholdExceeded;
+        if (_tokenCurrentVolume[token] > _periodTotalValueThreshold) {
+            return Const.FinalizeStatus.PeriodTotalValueThresholdExceeded;
         }
 
-        return status;
+        return Const.FinalizeStatus.Success;
     }
 
     /**

--- a/test/BSCBridgeV2.t.sol
+++ b/test/BSCBridgeV2.t.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import {BSCBridgeV2} from "../src/BSCBridgeV2.sol";
+import {BridgeVerifier} from "../src/BridgeVerifier.sol";
+import {Const} from "../src/lib/Const.sol";
+
+import {PriceFeed} from "../src/PriceFeed.sol";
+
+import {BridgeVerifier} from "../src/BridgeVerifier.sol";
+import {BridgeTest} from "./Bridge.t.sol";
+import {SettingTest} from "./chain/Setting.t.sol";
+import {TestToken} from "./token/TestToken.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {console} from "forge-std/Test.sol";
+
+contract BSCBridgeV2Test is BridgeTest {
+    BSCBridgeV2 internal bscBridgeV2Impl;
+    BSCBridgeV2 internal bridgeBSCV2;
+
+    address internal deadWallet = address(0x000000000000000000000000000000000000dEaD);
+
+    function setUp() public override {
+        super.setUp();
+
+        vm.selectFork(bscForkID);
+        vm.startPrank(OWNER);
+        bridgeBSC.upgradeToAndCall(
+            address(new BSCBridgeV2()), abi.encodeCall(BSCBridgeV2.reinitializeBSCBridge, (CROSS_CHAIN_ID, cross))
+        );
+        vm.stopPrank();
+
+        bridgeBSCV2 = BSCBridgeV2(address(bridgeBSC));
+    }
+
+    function test_burn_cross_to_dead_wallet() public {
+        vm.selectFork(bscForkID);
+        burnCrossToDeadWallet(false, OWNER, deadWallet, 1000 ether, true);
+    }
+
+    function test_burn_cross_to_dead_wallet_with_transfer() public {
+        vm.selectFork(bscForkID);
+        vm.prank(OWNER);
+        cross.approve(address(bridgeBSCV2), 1000 ether);
+        burnCrossToDeadWallet(false, OWNER, deadWallet, 1000 ether, false);
+    }
+
+    function test_fuzz_burn_cross_to_dead_wallet(uint amount) public {
+        vm.assume(amount > 0);
+
+        vm.selectFork(crossForkID);
+        vm.assume(amount < address(bridgeCross).balance);
+
+        // disable verification
+        vm.startPrank(CrossOWNER);
+        bridgeCross.setCrossSupplyLimit(INITIAL_SUPPLY);
+        bridgeVerifierCross.setVerificationAmountThreshold(0);
+        bridgeVerifierCross.setPeriodTotalValueThreshold(0);
+        vm.stopPrank();
+
+        vm.selectFork(bscForkID);
+        burnCrossToDeadWallet(false, OWNER, deadWallet, amount, true);
+    }
+
+    function test_fuzz_burn_cross_to_dead_wallet_with_transfer(uint amount) public {
+        vm.assume(amount > 0);
+
+        vm.selectFork(crossForkID);
+        vm.assume(amount < address(bridgeCross).balance);
+
+        // disable verification
+        vm.startPrank(CrossOWNER);
+        bridgeCross.setCrossSupplyLimit(INITIAL_SUPPLY);
+        bridgeVerifierCross.setVerificationAmountThreshold(0);
+        bridgeVerifierCross.setPeriodTotalValueThreshold(0);
+        vm.stopPrank();
+
+        vm.selectFork(bscForkID);
+        vm.assume(amount < cross.balanceOf(OWNER));
+
+        vm.prank(OWNER);
+        cross.approve(address(bridgeBSCV2), amount);
+        burnCrossToDeadWallet(false, OWNER, deadWallet, amount, false);
+    }
+}

--- a/test/Bridge.t.sol
+++ b/test/Bridge.t.sol
@@ -185,4 +185,44 @@ contract BridgeTest is BSCTest {
             assertEq(bridgeCoinBalance - value, address(bridgeBSC).balance);
         }
     }
+
+    // burn cross token to dead wallet (bsc -> cross chain)
+    function burnCrossToDeadWallet(
+        bool isRevert,
+        address from,
+        address deadWallet,
+        uint amount,
+        bool alreadyTransferred
+    ) public returns (uint index) {
+        vm.selectFork(bscForkID);
+        uint bscUserBalance = cross.balanceOf(from);
+        uint bscBridgeBalance = cross.balanceOf(address(bridgeBSC));
+        uint bscDeadWalletBalance = cross.balanceOf(deadWallet);
+        vm.selectFork(crossForkID);
+        uint crossDeadWalletBalance = deadWallet.balance;
+        uint crossBridgeBalance = address(bridgeCross).balance;
+
+        bool ok;
+        (index, ok) = bscBurnCrossToDeadWallet(from, deadWallet, amount, alreadyTransferred);
+        if (ok) {
+            if (enableGasUsedLog) console.log("bridge token (transfer)", uint(vm.lastCallGas().gasTotalUsed));
+            bscIncrementIndex();
+            ok = crossFinalize(index, address(NATIVE_TOKEN), deadWallet, amount, 5);
+            if (ok && enableGasUsedLog) console.log("finalize coin", uint(vm.lastCallGas().gasTotalUsed));
+        }
+
+        if (!isRevert) {
+            vm.selectFork(bscForkID);
+            if (alreadyTransferred) {
+                assertEq(bscUserBalance, cross.balanceOf(from));
+            } else {
+                assertEq(bscUserBalance - amount, cross.balanceOf(from));
+                assertEq(bscDeadWalletBalance + amount, cross.balanceOf(deadWallet));
+            }
+            assertEq(bscBridgeBalance, cross.balanceOf(address(bridgeBSC)));
+            vm.selectFork(crossForkID);
+            assertEq(crossDeadWalletBalance + amount, deadWallet.balance);
+            assertEq(crossBridgeBalance - amount, address(bridgeCross).balance);
+        }
+    }
 }

--- a/test/BridgeTokenMonitoring.t.sol
+++ b/test/BridgeTokenMonitoring.t.sol
@@ -81,10 +81,14 @@ contract BridgeVerifierTokenValueTest is BridgeTest {
         vm.selectFork(crossForkID);
         vm.startPrank(CrossOWNER);
 
+        uint score = bridgeVerifierCross.getTokenCurrentScore(testTokenCross);
+
         // Perform the rest of the test
         (Const.FinalizeStatus status) = bridgeVerifierCross.validateBridgeTokenValue(testTokenCross, 20 ether);
 
         assertTrue(status == Const.FinalizeStatus.VerificationAmountThresholdExceeded);
+        assertTrue(score == bridgeVerifierCross.getTokenCurrentScore(testTokenCross));
+
         vm.stopPrank();
     }
 

--- a/test/chain/BSC.t.sol
+++ b/test/chain/BSC.t.sol
@@ -8,6 +8,7 @@ import {IBridgeRegistry} from "../../src/interface/IBridgeRegistry.sol";
 import {TestToken} from "../token/TestToken.sol";
 import {CrossChainTest} from "./CrossChain.t.sol";
 
+import {BSCBridgeV2} from "../../src/BSCBridgeV2.sol";
 import {IPriceFeed, PriceFeed} from "../../src/PriceFeed.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -169,6 +170,23 @@ contract BSCTest is CrossChainTest {
             r,
             s
         );
+    }
+
+    function bscBurnCrossToDeadWallet(address from, address to, uint value, bool alreadyTransferred)
+        public
+        returns (uint index, bool ok)
+    {
+        vm.selectFork(bscForkID);
+        // burn cross to dead wallet
+        index = nextIndexBSC;
+        vm.prank(from);
+
+        if (bridgeRevertBSC) {
+            bridgeRevertBSC = false;
+            vm.expectRevert();
+        }
+
+        ok = BSCBridgeV2(address(bridgeBSC)).burnCrossToDeadWallet(to, value, alreadyTransferred);
     }
 
     function bscCalcFee(IERC20 token, uint totalValue) public returns (uint value, uint gas, uint ex) {

--- a/test/chain/CrossChain.t.sol
+++ b/test/chain/CrossChain.t.sol
@@ -40,7 +40,7 @@ contract CrossChainTest is SettingTest {
             CrossBridge bridgeCrossImpl = new CrossBridge();
             ERC1967Proxy bridgeCrossProxy = new ERC1967Proxy(address(bridgeCrossImpl), bytes(""));
             bridgeCross = CrossBridge(payable(address(bridgeCrossProxy)));
-            vm.deal(address(bridgeCross), INITIAL_SUPPLY);
+            vm.deal(address(bridgeCross), INITIAL_SUPPLY - CROSS_FOUNDATION_INITIAL_SUPPLY);
             bridgeCross.initializeCrossBridge(
                 CrossOWNER, REWARD, threshold, BSC_CHAIN_ID, address(cross), CROSS_FOUNDATION_INITIAL_SUPPLY
             );


### PR DESCRIPTION
#### Title
BSCBridgeV2 burn-to-dead-wallet flow + verifier/bridge refinements and comprehensive tests

#### Summary
- Introduces `BSCBridgeV2` with a unified burn-to-dead-wallet entrypoint and clear admin/user modes.
- Refines base and verifier logic for zero-value handling and threshold checks.
- Adds focused test coverage for the new burn flow and related edge cases.

#### Changes
- Core
  - Added `src/BSCBridgeV2.sol` with `burnCrossToDeadWallet(deadWallet, amount, alreadyTransferred)`:
    - `alreadyTransferred == false`: transfers caller’s CROSS to `deadWallet`, emits `BridgeInitiated` with `from = caller`.
    - `alreadyTransferred == true`: admin-only, no local transfer, emits `BridgeInitiated` with `from = bridge`.
    - Guarded by `whenNotPaused` and `nonReentrant`; `deadWallet` allowlist enforced.
  - `src/BaseBridge.sol`:
    - Initiate pre-check tightened: require `value != 0` alongside minimum and fee checks.
  - `src/BridgeVerifier.sol`:
    - Early return when verification amount threshold is exceeded.
    - If monitoring is disabled (`_timeWindow == 0 || _periodTotalValueThreshold == 0`), return Success early.
    - Keep volume update strictly after overflow and threshold checks.
- Config
  - `foundry.toml`: set `optimizer_runs = 1` (faster iteration).
- Tests
  - Added `test/BSCBridgeV2.t.sol` covering:
    - User mode (transfer + emit), Admin mode (emit-only), invalid dead wallet, zero amount, paused state.
    - Fuzz scenarios for both modes.
  - Extended existing harness files to integrate the new bridge and test helpers.

#### Rationale
- Single explicit API improves clarity and reduces surface area.
- Verifier logic is now consistent and guards against accidental overriding of failure states.
- Tests ensure the new flow works end-to-end and prevent regressions.

#### Migration
- Use `burnCrossToDeadWallet(deadWallet, amount, alreadyTransferred)` for burn scenarios.
- Ensure admin role when using `alreadyTransferred == true`.
- Off-chain consumers can rely on `from` to distinguish modes.

### Event Payload Decision
Decide whether to include a burn-related marker in `BridgeInitiated.extraData` (e.g., `abi.encodePacked(bytes4(keccak256("burnCrossToDeadWallet(address,uint256,bool)")))`). If not included, keep `extraData` empty for minimal payload.

### Build Note
When compiling BSCBridgeV2, use the Foundry “v2” profile.

```bash
FOUNDRY_PROFILE=v2 forge compile
```
