### PR TITLE
feat: integrate AccessControlDefaultAdminRules in CrossMintable tokens

### DIFF
--- a/src/lib/Const.sol
+++ b/src/lib/Const.sol
@@ -44,4 +44,5 @@ library Const {
     bytes32 internal constant PRICER_ROLE = keccak256("PRICER_ROLE");
     bytes32 internal constant VERIFIER_ROLE = keccak256("VERIFIER_ROLE");
     bytes32 internal constant BRIDGE_ROLE = keccak256("BRIDGE_ROLE");
+    bytes32 internal constant MINTER_ROLE = keccak256("MINTER_ROLE");
 }

--- a/src/token/CrossMintableERC20V2.sol
+++ b/src/token/CrossMintableERC20V2.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Const} from "../lib/Const.sol";
+import {ICrossMintableERC20} from "./ICrossMintableERC20.sol";
+import {AccessControlDefaultAdminRules} from
+    "@openzeppelin/contracts/access/extensions/AccessControlDefaultAdminRules.sol";
+import {ERC20, ERC20Permit, IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+
+contract CrossMintableERC20V2 is ERC20, ERC20Permit, ICrossMintableERC20, AccessControlDefaultAdminRules {
+    error CrossMintableERC20V2MinterNotGranted();
+
+    uint8 private immutable _decimals;
+
+    constructor(
+        address initialOwner,
+        address initialMinter,
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_
+    ) ERC20(name_, symbol_) ERC20Permit(name_) AccessControlDefaultAdminRules(0, initialOwner) {
+        if (initialMinter != address(0)) {
+            // Grant the minter role to the bridge
+            _grantRole(Const.MINTER_ROLE, initialMinter);
+        }
+
+        _decimals = decimals_;
+    }
+
+    function mint(address _account, uint _amount) external onlyRole(Const.MINTER_ROLE) returns (bool) {
+        _mint(_account, _amount);
+        return true;
+    }
+
+    function burn(address _account, uint _amount) external onlyRole(Const.MINTER_ROLE) returns (bool) {
+        _burn(_account, _amount);
+        return true;
+    }
+
+    function decimals() public view override(ERC20, ICrossMintableERC20) returns (uint8) {
+        return _decimals;
+    }
+
+    function nonces(address owner_) public view override(ERC20Permit, ICrossMintableERC20) returns (uint) {
+        return super.nonces(owner_);
+    }
+}

--- a/src/token/CrossMintableERC20V2Code.sol
+++ b/src/token/CrossMintableERC20V2Code.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Const} from "../lib/Const.sol";
+import {CrossMintableERC20V2} from "./CrossMintableERC20V2.sol";
+import {ICrossMintableERC20Code} from "./ICrossMintableERC20Code.sol";
+import {AccessControlDefaultAdminRules} from
+    "@openzeppelin/contracts/access/extensions/AccessControlDefaultAdminRules.sol";
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+
+contract CrossMintableERC20V2Code is AccessControlDefaultAdminRules, ICrossMintableERC20Code {
+    error ERC20CodeNotBridge(address account);
+
+    constructor(address initialOwner, address initialBridge) AccessControlDefaultAdminRules(0, initialOwner) {
+        grantRole(Const.BRIDGE_ROLE, initialBridge);
+    }
+
+    function createCrossMintableERC20(uint remoteChainID, address remoteToken, string memory symbol, uint8 decimals)
+        external
+        onlyRole(Const.BRIDGE_ROLE)
+        returns (address tokenAddress)
+    {
+        bytes32 salt = keccak256(abi.encodePacked(remoteChainID, remoteToken));
+        bytes memory bytecode = abi.encodePacked(
+            type(CrossMintableERC20V2).creationCode,
+            abi.encode(
+                defaultAdmin(), // Initial owner
+                _msgSender(), // Initial minter
+                string(abi.encodePacked("Cross Bridge ", symbol)),
+                abi.encodePacked(symbol, "x"),
+                decimals
+            )
+        ); // Combine creation code and constructor arguments
+        tokenAddress = Create2.deploy(0, salt, bytecode); // Deploy the wrapped token using Create2
+    }
+}

--- a/test/CrossMintableERC20V2.t.sol
+++ b/test/CrossMintableERC20V2.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Const} from "../src/lib/Const.sol";
+import {CrossMintableERC20V2} from "../src/token/CrossMintableERC20V2.sol";
+import {CrossMintableERC20V2Code} from "../src/token/CrossMintableERC20V2Code.sol";
+import {Test} from "forge-std/Test.sol";
+import {console} from "forge-std/Test.sol";
+
+contract CrossMintableERC20V2Test is Test {
+    CrossMintableERC20V2Code public crossMintableERC20Code;
+    CrossMintableERC20V2 public crossMintableERC20;
+
+    address public owner;
+    address public minter; // minter is the bridge
+
+    uint internal constant OWNER_PK = uint(bytes32("owner"));
+    uint internal constant MINTER_PK = uint(bytes32("minter"));
+
+    uint internal constant INITIAL_SUPPLY = 1_000_000_000 ether;
+
+    string internal constant SYMBOL = "TEST";
+    uint8 internal constant DECIMALS = 18;
+
+    function setUp() public {
+        owner = vm.addr(OWNER_PK);
+        minter = vm.addr(MINTER_PK);
+
+        vm.prank(owner);
+        crossMintableERC20Code = new CrossMintableERC20V2Code(owner, minter);
+        console.log("crossMintableERC20Code", address(crossMintableERC20Code));
+
+        vm.prank(minter);
+        crossMintableERC20 =
+            CrossMintableERC20V2(crossMintableERC20Code.createCrossMintableERC20(1, address(1), SYMBOL, DECIMALS));
+        console.log("crossMintableERC20", address(crossMintableERC20));
+
+        vm.prank(owner);
+        crossMintableERC20.grantRole(Const.MINTER_ROLE, minter);
+    }
+
+    function test_mint() public {
+        vm.prank(minter);
+        crossMintableERC20.mint(owner, INITIAL_SUPPLY);
+        assertEq(crossMintableERC20.balanceOf(owner), INITIAL_SUPPLY);
+    }
+
+    function test_burn() public {
+        vm.prank(minter);
+        crossMintableERC20.burn(owner, INITIAL_SUPPLY);
+        assertEq(crossMintableERC20.balanceOf(owner), 0);
+    }
+}


### PR DESCRIPTION
- Add role-based access control for minting and burning functions
- Remove bridge address related code
- Set initial owner and bridge role in constructor