### PR TITLE
Implement INITIATOR_ROLE for permitBridgeToken and enhance security

### DIFF
--- a/src/BaseBridge.sol
+++ b/src/BaseBridge.sol
@@ -309,10 +309,9 @@ contract BaseBridge is
             BaseBridgeInvalidPermitToken(address(fromToken), address(permitArgs.token))
         );
 
-        // The permitBridgeToken function doesn't restrict msg.sender, allowing anyone to initiate the bridge operation.
-        // However, it requires that 'to' matches permitArgs.account to ensure that the recipient on the target chain
-        // is the same as the account that signed the permit. This restriction provides protection against front-running
-        // by enforcing that only the intended recipient can receive the bridged tokens.
+        // The permitBridgeToken function restricts msg.sender to INITIATOR_ROLE,
+        // preventing third parties from injecting unauthorized bridge parameters
+        // (toChainID, value, extraData) using a stolen or front-run permit.
         require(to == permitArgs.account, BaseBridgeMismatchPermitAccount());
         require(_maxExtraDataLength == 0 || extraData.length <= _maxExtraDataLength, BaseBridgeExtraDataTooLong());
 
@@ -357,6 +356,7 @@ contract BaseBridge is
         payable
         whenNotPaused
         nonReentrant
+        onlyRole(Const.INITIATOR_ROLE)
     {
         require(args.length == permitArgs.length, BaseBridgeNotMatchLength());
         for (uint i = 0; i < args.length; ++i) {

--- a/src/lib/Const.sol
+++ b/src/lib/Const.sol
@@ -46,4 +46,5 @@ library Const {
     bytes32 internal constant BRIDGE_ROLE = keccak256("BRIDGE_ROLE");
     bytes32 internal constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 internal constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
+    bytes32 internal constant INITIATOR_ROLE = keccak256("INITIATOR_ROLE");
 }

--- a/test/BridgeStandard.t.sol
+++ b/test/BridgeStandard.t.sol
@@ -501,6 +501,36 @@ contract BaseBridgeTest is BridgeTest {
         bridgeBSC.setMaxExtraDataLength(0);
     }
 
+    /**
+     * @notice Test that permitBridgeTokenBatch reverts when called by unauthorized address
+     */
+    function test_permit_revert_unauthorized_caller() public {
+        uint amount = 1000 * 1e18;
+
+        vm.selectFork(bscForkID);
+        vm.prank(OWNER);
+        cross.transfer(USER, amount);
+
+        IBaseBridge.PermitArguments memory permitArgs;
+        {
+            uint deadline = type(uint).max;
+            uint nonce = IERC20Permit(address(cross)).nonces(USER);
+            bytes32 h = keccak256(abi.encode(PERMIT_TYPEHASH, USER, address(bridgeBSC), amount, nonce, deadline));
+            bytes32 hash = MessageHashUtils.toTypedDataHash(IERC20Permit(address(cross)).DOMAIN_SEPARATOR(), h);
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(USER_PK, hash);
+            permitArgs = IBaseBridge.PermitArguments(IERC20Permit(address(cross)), USER, amount, deadline, v, r, s);
+        }
+
+        IBaseBridge.BridgeTokenArguments[] memory args = new IBaseBridge.BridgeTokenArguments[](1);
+        args[0] = IBaseBridge.BridgeTokenArguments(CROSS_CHAIN_ID, cross, USER, USER, amount, 0, 0, "");
+        IBaseBridge.PermitArguments[] memory permitArgsArray = new IBaseBridge.PermitArguments[](1);
+        permitArgsArray[0] = permitArgs;
+
+        vm.prank(USER);
+        vm.expectRevert();
+        bridgeBSC.permitBridgeTokenBatch(args, permitArgsArray);
+    }
+
     function test_permit_deposit_batch() public {
         // not allow fail
         uint amount = 1000 * 1e18;

--- a/test/chain/BSC.t.sol
+++ b/test/chain/BSC.t.sol
@@ -48,6 +48,7 @@ contract BSCTest is CrossChainTest {
                 roles[i] = VALIDATOR_ROLE;
             }
             bridgeBSC.grantRoleBatch(roles, VALIDATORS);
+            bridgeBSC.grantRole(INITIATOR_ROLE, VALIDATOR1);
         }
 
         {

--- a/test/chain/Setting.t.sol
+++ b/test/chain/Setting.t.sol
@@ -22,6 +22,7 @@ contract SettingTest is Test {
     bytes32 public constant PRICER_ROLE = Const.PRICER_ROLE;
     bytes32 public constant ADMIN_ROLE = Const.ADMIN_ROLE;
     bytes32 public constant VERIFIER_ROLE = Const.VERIFIER_ROLE;
+    bytes32 public constant INITIATOR_ROLE = Const.INITIATOR_ROLE;
 
     uint internal constant OWNER_PK = uint(bytes32("owner"));
     uint internal constant CrossOWNER_PK = uint(bytes32("cross_owner"));


### PR DESCRIPTION
- Restricted msg.sender in permitBridgeToken to INITIATOR_ROLE to prevent unauthorized access.
- Added INITIATOR_ROLE constant in Const.sol for role management.
- Introduced a test to verify that permitBridgeTokenBatch reverts when called by an unauthorized address.
- Updated BSC tests to grant INITIATOR_ROLE to a validator.