### PR TITLE
Enhance permit bridge flow with extraData support and INITIATOR_ROLE

### DIFF
--- a/src/BaseBridge.sol
+++ b/src/BaseBridge.sol
@@ -301,7 +301,8 @@ contract BaseBridge is
         uint value,
         uint networkFee,
         uint exFee,
-        PermitArguments calldata permitArgs
+        PermitArguments calldata permitArgs,
+        bytes calldata extraData
     ) private onlyValidToken(toChainID, address(fromToken)) {
         require(
             address(fromToken) == address(permitArgs.token),
@@ -313,6 +314,7 @@ contract BaseBridge is
         // is the same as the account that signed the permit. This restriction provides protection against front-running
         // by enforcing that only the intended recipient can receive the bridged tokens.
         require(to == permitArgs.account, BaseBridgeMismatchPermitAccount());
+        require(_maxExtraDataLength == 0 || extraData.length <= _maxExtraDataLength, BaseBridgeExtraDataTooLong());
 
         (networkFee, exFee) = _checkInitiateAmount(toChainID, fromToken, value, networkFee, exFee);
         require(
@@ -340,7 +342,7 @@ contract BaseBridge is
                 value: value,
                 networkFee: networkFee,
                 exFee: exFee,
-                extraData: "" // Empty: extraData not supported in permit flow
+                extraData: extraData
             })
         );
     }
@@ -365,7 +367,8 @@ contract BaseBridge is
                 args[i].value,
                 args[i].networkFee,
                 args[i].exFee,
-                permitArgs[i]
+                permitArgs[i],
+                args[i].extraData
             );
         }
     }

--- a/src/BaseBridge.sol
+++ b/src/BaseBridge.sol
@@ -309,10 +309,9 @@ contract BaseBridge is
             BaseBridgeInvalidPermitToken(address(fromToken), address(permitArgs.token))
         );
 
-        // The permitBridgeToken function doesn't restrict msg.sender, allowing anyone to initiate the bridge operation.
-        // However, it requires that 'to' matches permitArgs.account to ensure that the recipient on the target chain
-        // is the same as the account that signed the permit. This restriction provides protection against front-running
-        // by enforcing that only the intended recipient can receive the bridged tokens.
+        // The permitBridgeToken function restricts msg.sender to INITIATOR_ROLE,
+        // preventing third parties from injecting unauthorized bridge parameters
+        // (toChainID, value, extraData) using a stolen or front-run permit.
         require(to == permitArgs.account, BaseBridgeMismatchPermitAccount());
         require(_maxExtraDataLength == 0 || extraData.length <= _maxExtraDataLength, BaseBridgeExtraDataTooLong());
 
@@ -357,6 +356,7 @@ contract BaseBridge is
         payable
         whenNotPaused
         nonReentrant
+        onlyRole(Const.INITIATOR_ROLE)
     {
         require(args.length == permitArgs.length, BaseBridgeNotMatchLength());
         for (uint i = 0; i < args.length; ++i) {

--- a/src/lib/Const.sol
+++ b/src/lib/Const.sol
@@ -46,4 +46,5 @@ library Const {
     bytes32 internal constant BRIDGE_ROLE = keccak256("BRIDGE_ROLE");
     bytes32 internal constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 internal constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
+    bytes32 internal constant INITIATOR_ROLE = keccak256("INITIATOR_ROLE");
 }

--- a/test/BridgeStandard.t.sol
+++ b/test/BridgeStandard.t.sol
@@ -362,10 +362,10 @@ contract BaseBridgeTest is BridgeTest {
     }
 
     /**
-     * @notice Test that permitBridgeTokenBatch ignores caller-supplied extraData
-     * @dev Even when non-empty extraData is provided, the emitted event should have empty extraData
+     * @notice Test that permitBridgeTokenBatch passes caller-supplied extraData
+     * @dev When non-empty extraData is provided, the emitted event should contain the same extraData
      */
-    function test_permit_extraData_ignored() public {
+    function test_permit_extraData_passed() public {
         uint amount = 1000 * 1e18;
 
         vm.selectFork(bscForkID);
@@ -383,14 +383,11 @@ contract BaseBridgeTest is BridgeTest {
             permitArgs = IBaseBridge.PermitArguments(IERC20Permit(address(cross)), USER, amount, deadline, v, r, s);
         }
 
-        // Prepare malicious extraData that attacker might try to inject
-        bytes memory maliciousExtraData = abi.encodePacked(address(0xDEAD), bytes4(0x12345678), bytes("attack"));
+        bytes memory extraData = abi.encodePacked(address(0xDEAD), bytes4(0x12345678), bytes("payload"));
 
-        // Get expected values for event assertion
         uint expectedIndex = bridgeBSC.getNextInitiateIndex(CROSS_CHAIN_ID);
         address expectedRemoteToken = bridgeBSC.getTokenPair(CROSS_CHAIN_ID, address(cross)).remoteToken;
 
-        // Expect BridgeInitiated event with EMPTY extraData (not maliciousExtraData)
         vm.expectEmit(true, true, true, true);
         emit BaseBridge.BridgeInitiated(
             CROSS_CHAIN_ID,
@@ -402,13 +399,12 @@ contract BaseBridgeTest is BridgeTest {
             amount,
             0,
             0,
-            "", // KEY: extraData must be empty, not maliciousExtraData
+            extraData,
             block.timestamp
         );
 
-        // Call with non-empty extraData - it should be ignored
         IBaseBridge.BridgeTokenArguments[] memory args = new IBaseBridge.BridgeTokenArguments[](1);
-        args[0] = IBaseBridge.BridgeTokenArguments(CROSS_CHAIN_ID, cross, USER, USER, amount, 0, 0, maliciousExtraData);
+        args[0] = IBaseBridge.BridgeTokenArguments(CROSS_CHAIN_ID, cross, USER, USER, amount, 0, 0, extraData);
         IBaseBridge.PermitArguments[] memory permitArgsArray = new IBaseBridge.PermitArguments[](1);
         permitArgsArray[0] = permitArgs;
         vm.prank(VALIDATOR1);
@@ -416,10 +412,10 @@ contract BaseBridgeTest is BridgeTest {
     }
 
     /**
-     * @notice Test that permitBridgeTokenBatch ignores extraData in args
-     * @dev Even when BridgeTokenArguments contain non-empty extraData, emitted events should have empty extraData
+     * @notice Test that permitBridgeTokenBatch passes extraData from args
+     * @dev When BridgeTokenArguments contain non-empty extraData, emitted events should contain the same extraData
      */
-    function test_permit_batch_extraData_ignored() public {
+    function test_permit_batch_extraData_passed() public {
         uint amount = 1000 * 1e18;
 
         vm.selectFork(bscForkID);
@@ -437,20 +433,17 @@ contract BaseBridgeTest is BridgeTest {
             permitArgs = IBaseBridge.PermitArguments(IERC20Permit(address(cross)), USER, amount, deadline, v, r, s);
         }
 
-        // Prepare malicious extraData
-        bytes memory maliciousExtraData = abi.encodePacked(address(0xDEAD), bytes4(0x12345678));
+        bytes memory extraData = abi.encodePacked(address(0xDEAD), bytes4(0x12345678));
 
         IBaseBridge.BridgeTokenArguments[] memory args = new IBaseBridge.BridgeTokenArguments[](1);
-        args[0] = IBaseBridge.BridgeTokenArguments(CROSS_CHAIN_ID, cross, USER, USER, amount, 0, 0, maliciousExtraData);
+        args[0] = IBaseBridge.BridgeTokenArguments(CROSS_CHAIN_ID, cross, USER, USER, amount, 0, 0, extraData);
 
         IBaseBridge.PermitArguments[] memory permitArgsArray = new IBaseBridge.PermitArguments[](1);
         permitArgsArray[0] = permitArgs;
 
-        // Get expected values for event assertion
         uint expectedIndex = bridgeBSC.getNextInitiateIndex(CROSS_CHAIN_ID);
         address expectedRemoteToken = bridgeBSC.getTokenPair(CROSS_CHAIN_ID, address(cross)).remoteToken;
 
-        // Expect BridgeInitiated event with EMPTY extraData
         vm.expectEmit(true, true, true, true);
         emit BaseBridge.BridgeInitiated(
             CROSS_CHAIN_ID,
@@ -462,12 +455,50 @@ contract BaseBridgeTest is BridgeTest {
             amount,
             0,
             0,
-            "", // KEY: extraData must be empty
+            extraData,
             block.timestamp
         );
 
         vm.prank(VALIDATOR1);
         bridgeBSC.permitBridgeTokenBatch(args, permitArgsArray);
+    }
+
+    /**
+     * @notice Test that permitBridgeTokenBatch reverts when extraData exceeds maxExtraDataLength
+     */
+    function test_permit_extraData_length_validation() public {
+        uint amount = 1000 * 1e18;
+
+        vm.selectFork(bscForkID);
+        vm.prank(OWNER);
+        cross.transfer(USER, amount);
+
+        vm.prank(OWNER);
+        bridgeBSC.setMaxExtraDataLength(32);
+
+        IBaseBridge.PermitArguments memory permitArgs;
+        {
+            uint deadline = type(uint).max;
+            uint nonce = IERC20Permit(address(cross)).nonces(USER);
+            bytes32 h = keccak256(abi.encode(PERMIT_TYPEHASH, USER, address(bridgeBSC), amount, nonce, deadline));
+            bytes32 hash = MessageHashUtils.toTypedDataHash(IERC20Permit(address(cross)).DOMAIN_SEPARATOR(), h);
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(USER_PK, hash);
+            permitArgs = IBaseBridge.PermitArguments(IERC20Permit(address(cross)), USER, amount, deadline, v, r, s);
+        }
+
+        bytes memory tooLongExtraData = new bytes(33);
+
+        IBaseBridge.BridgeTokenArguments[] memory args = new IBaseBridge.BridgeTokenArguments[](1);
+        args[0] = IBaseBridge.BridgeTokenArguments(CROSS_CHAIN_ID, cross, USER, USER, amount, 0, 0, tooLongExtraData);
+        IBaseBridge.PermitArguments[] memory permitArgsArray = new IBaseBridge.PermitArguments[](1);
+        permitArgsArray[0] = permitArgs;
+
+        vm.prank(VALIDATOR1);
+        vm.expectRevert(BaseBridge.BaseBridgeExtraDataTooLong.selector);
+        bridgeBSC.permitBridgeTokenBatch(args, permitArgsArray);
+
+        vm.prank(OWNER);
+        bridgeBSC.setMaxExtraDataLength(0);
     }
 
     function test_permit_deposit_batch() public {

--- a/test/BridgeStandard.t.sol
+++ b/test/BridgeStandard.t.sol
@@ -501,6 +501,36 @@ contract BaseBridgeTest is BridgeTest {
         bridgeBSC.setMaxExtraDataLength(0);
     }
 
+    /**
+     * @notice Test that permitBridgeTokenBatch reverts when called by unauthorized address
+     */
+    function test_permit_revert_unauthorized_caller() public {
+        uint amount = 1000 * 1e18;
+
+        vm.selectFork(bscForkID);
+        vm.prank(OWNER);
+        cross.transfer(USER, amount);
+
+        IBaseBridge.PermitArguments memory permitArgs;
+        {
+            uint deadline = type(uint).max;
+            uint nonce = IERC20Permit(address(cross)).nonces(USER);
+            bytes32 h = keccak256(abi.encode(PERMIT_TYPEHASH, USER, address(bridgeBSC), amount, nonce, deadline));
+            bytes32 hash = MessageHashUtils.toTypedDataHash(IERC20Permit(address(cross)).DOMAIN_SEPARATOR(), h);
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(USER_PK, hash);
+            permitArgs = IBaseBridge.PermitArguments(IERC20Permit(address(cross)), USER, amount, deadline, v, r, s);
+        }
+
+        IBaseBridge.BridgeTokenArguments[] memory args = new IBaseBridge.BridgeTokenArguments[](1);
+        args[0] = IBaseBridge.BridgeTokenArguments(CROSS_CHAIN_ID, cross, USER, USER, amount, 0, 0, "");
+        IBaseBridge.PermitArguments[] memory permitArgsArray = new IBaseBridge.PermitArguments[](1);
+        permitArgsArray[0] = permitArgs;
+
+        vm.prank(USER);
+        vm.expectRevert();
+        bridgeBSC.permitBridgeTokenBatch(args, permitArgsArray);
+    }
+
     function test_permit_deposit_batch() public {
         // not allow fail
         uint amount = 1000 * 1e18;

--- a/test/chain/BSC.t.sol
+++ b/test/chain/BSC.t.sol
@@ -48,6 +48,7 @@ contract BSCTest is CrossChainTest {
                 roles[i] = VALIDATOR_ROLE;
             }
             bridgeBSC.grantRoleBatch(roles, VALIDATORS);
+            bridgeBSC.grantRole(INITIATOR_ROLE, VALIDATOR1);
         }
 
         {

--- a/test/chain/Setting.t.sol
+++ b/test/chain/Setting.t.sol
@@ -22,6 +22,7 @@ contract SettingTest is Test {
     bytes32 public constant PRICER_ROLE = Const.PRICER_ROLE;
     bytes32 public constant ADMIN_ROLE = Const.ADMIN_ROLE;
     bytes32 public constant VERIFIER_ROLE = Const.VERIFIER_ROLE;
+    bytes32 public constant INITIATOR_ROLE = Const.INITIATOR_ROLE;
 
     uint internal constant OWNER_PK = uint(bytes32("owner"));
     uint internal constant CrossOWNER_PK = uint(bytes32("cross_owner"));


### PR DESCRIPTION
## Summary
- `permitBridgeTokenBatch`에 `extraData` 지원 추가하여 permit 기반 브리지에서도 destination-side 실행 가능
- `INITIATOR_ROLE` 권한 제한 적용으로 permit 플로우의 보안 강화 (오딧 Finding 9 대응)
- 권한 없는 호출자 검증 테스트 추가

## Changes
- `BaseBridge.sol`: `_permitBridgeToken`에 `extraData` 파라미터 추가, `permitBridgeTokenBatch`에 `onlyRole(Const.INITIATOR_ROLE)` modifier 적용
- `Const.sol`: `INITIATOR_ROLE` 상수 추가
- `BridgeStandard.t.sol`: extraData 전달 테스트, 길이 검증 테스트, 권한 미부여 호출자 revert 테스트 추가

## Test plan
- [x] `test_permit_extraData_passed` — permit 플로우에서 extraData가 정상 전달되는지 확인
- [x] `test_permit_batch_extraData_passed` — 배치 호출에서 extraData 전달 확인
- [x] `test_permit_extraData_length_validation` — maxExtraDataLength 초과 시 revert 확인
- [x] `test_permit_revert_unauthorized_caller` — INITIATOR_ROLE 미보유 호출자 revert 확인
- [x] 전체 181개 테스트 통과 확인


Made with [Cursor](https://cursor.com)