### PR TITLE
docs: rewrite README for external audience (EN + KO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,680 @@
-## Foundry
+# Cross Bridge Contracts
 
-**Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
+Smart contracts for the **Cross Bridge** — a multi-signature cross-chain bridge that moves tokens
+between the Cross chain and external EVM chains such as BSC.
 
-Foundry consists of:
+한국어 문서: [README_KO.md](README_KO.md)
 
--   **Forge**: Ethereum testing framework (like Truffle, Hardhat and DappTools).
--   **Cast**: Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain data.
--   **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.
--   **Chisel**: Fast, utilitarian, and verbose solidity REPL.
+---
 
-## Documentation
+## Contents
 
-https://book.getfoundry.sh/
+- [1. Overview](#1-overview)
+- [2. How a transfer works](#2-how-a-transfer-works)
+- [3. Token model](#3-token-model)
+- [4. User-facing API](#4-user-facing-api)
+  - [4.1 `bridgeToken` — start a transfer](#41-bridgetoken--start-a-transfer)
+  - [4.2 Quoting fees before you send](#42-quoting-fees-before-you-send)
+  - [4.3 `extraData` — bridge and call in one step](#43-extradata--bridge-and-call-in-one-step)
+  - [4.4 `finalizeBridgeBatch` — settlement on the destination chain](#44-finalizebridgebatch--settlement-on-the-destination-chain)
+  - [4.5 Held (pending) transfers and `releasePending`](#45-held-pending-transfers-and-releasepending)
+  - [4.6 Read-only functions for tracking](#46-read-only-functions-for-tracking)
+  - [4.7 Chain-specific and auxiliary entry points](#47-chain-specific-and-auxiliary-entry-points)
+- [5. Validator network](#5-validator-network)
+- [6. Security and trust model](#6-security-and-trust-model)
+- [7. Contracts](#7-contracts)
+- [8. Roles](#8-roles)
+- [9. Events](#9-events)
+- [10. Build and test](#10-build-and-test)
+- [11. Go bindings](#11-go-bindings)
+- [12. License](#12-license)
 
-## Usage
+---
 
-### Build
+## 1. Overview
 
-```shell
-$ forge build
+The bridge does not relay messages between chains. Instead:
+
+1. A user deposits (or burns) tokens on the **source chain**, which emits a `BridgeInitiated` event.
+2. An off-chain **validator network** observes that event and each validator produces an EIP-712 signature
+   over the transfer details.
+3. Once enough signatures exist, a settlement transaction is submitted on the **destination chain**, where
+   the bridge contract verifies the signatures and pays out to the recipient.
+
+Every transfer is assigned a **monotonically increasing index** per chain pair, and the destination chain
+accepts only the next expected index. A settlement therefore cannot be replayed, skipped, or accepted out of
+order. A transfer that is accepted but held for review still advances the index, so its payout may complete
+after later transfers.
+
+The authorization model for settlement is a **`threshold`-of-`N` multi-signature**: the contract verifies
+that enough distinct addresses currently holding the validator role signed the exact transfer being settled.
+Governance (role membership, threshold, upgrades, limits) is separately administered — see
+[§6](#6-security-and-trust-model).
+
+---
+
+## 2. How a transfer works
+
+```mermaid
+graph LR
+    subgraph SRC["Source chain"]
+        U["User / Router / Contract"]
+        SB["Bridge"]
+        U -->|"bridgeToken(...)"| SB
+    end
+
+    VN["Validator network<br/>(off-chain, threshold-of-N)"]
+
+    subgraph DST["Destination chain"]
+        DB["Bridge"]
+        R["Recipient"]
+        X["Whitelisted target contract<br/>(optional, via extraData)"]
+        DB --> R
+        DB -.-> X
+    end
+
+    SB -.->|"BridgeInitiated event"| VN
+    VN -->|"signed settlement tx"| DB
 ```
 
-### Test
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant SB as Source bridge
+    participant VN as Validator network
+    participant DB as Destination bridge
 
-```shell
-$ forge test
+    User->>SB: bridgeToken(toChainID, token, to, value, networkFee, exFee, extraData)
+    SB->>SB: lock or burn tokens, collect recomputed fees
+    SB-->>User: BridgeInitiated(toChainID, index, ...)
+    SB-->>VN: event observed
+    VN->>VN: each validator signs the transfer (EIP-712)
+    VN->>DB: finalizeBridgeBatch(args, signatures)
+    DB->>DB: verify signatures + expected index + safety limits
+    alt within limits and payout succeeds
+        DB->>User: tokens released or minted to `to`
+        DB-->>VN: BridgeFinalized
+    else limit exceeded or recognized payout failure
+        DB->>DB: transfer held for review
+        DB-->>VN: BridgePending(status)
+    end
 ```
 
-### Format
+---
 
-```shell
-$ forge fmt
+## 3. Token model
+
+Each bridgeable token is registered as a **pair** of a local token and its counterpart on a remote chain.
+One side of the pair is the **origin** (where the real token lives); the other side holds a **wrapped**
+token issued by the bridge.
+
+| Direction | Source chain | Destination chain |
+|---|---|---|
+| origin → wrapped | tokens are **locked** in the bridge | wrapped tokens are **minted** to the recipient |
+| wrapped → origin | wrapped tokens are **burned** | locked original tokens are **released** |
+
+Consequences for users:
+
+- Bridge settlement mints wrapped tokens only after threshold signature verification. Each bridge keeps its own
+  local accounting of locked and minted amounts, and an outgoing wrapped transfer cannot exceed the amount
+  available in that bridge's local minted accounting for the pair.
+- Minting authority on the wrapped token is a **separate trust boundary**. Two implementations exist, so
+  identify which one a pair actually uses: `CrossMintableERC20V2` grants `MINTER_ROLE` to the bridge when the
+  token is created, but the token's own default administrator can grant that role to further addresses, and
+  additional minters make the token's real supply diverge from the bridge's accounting. V2 exposes no
+  member-enumeration function, so if you rely on the 1:1 relationship, reconstruct membership from the token's
+  `RoleGranted` / `RoleRevoked` history since deployment and confirm individual addresses with `hasRole`. The
+  earlier `CrossMintableERC20` instead hard-codes an immutable bridge address as its only minter and burner.
+- **Token compatibility is an assumption, not an enforcement.** The bridge records the nominal `value` it
+  requested, without measuring the balance actually received. A registered origin token is therefore expected
+  to transfer exactly the requested amount and to keep balances stable on its own. Fee-on-transfer and rebasing
+  behaviour makes bridge accounting diverge from real custody directly; callback-bearing or otherwise
+  non-standard tokens require an explicit compatibility and reentrancy review. None of these should be assumed
+  supported.
+- Native coins (e.g. CROSS, BNB, ETH) are represented by the reserved address `0x00...01`
+  (`Const.NATIVE_TOKEN`) when used as a token argument.
+- Wrapped tokens are standard `ERC20` + `ERC20Permit` contracts deployed by the bridge, named
+  `Cross Bridge <SYMBOL>` with symbol `<SYMBOL>x`, using the symbol and decimals supplied at registration
+  time. Always read `decimals()` from the token rather than assuming it matches the origin token.
+- A transfer is only possible for a **registered** pair. Use `allChainIDs()` / `allTokenPairs()` /
+  `getTokenPair()` to discover what is supported on a given deployment.
+
+---
+
+## 4. User-facing API
+
+### 4.1 `bridgeToken` — start a transfer
+
+This is the single entry point for regular users. It is called **on the source chain**.
+
+```solidity
+function bridgeToken(
+    uint toChainID,
+    IERC20 fromToken,
+    address to,
+    uint value,
+    uint networkFee,
+    uint exFee,
+    bytes calldata extraData
+) external payable returns (bool);
 ```
 
-### Gas Snapshots
+| Argument | Description |
+|---|---|
+| `toChainID` | Destination chain ID. Must be a chain for which `fromToken` has a registered pair. |
+| `fromToken` | Token to send **on the source chain**. Use `0x00...01` for the native coin. |
+| `to` | Recipient address on the destination chain. Cannot be the zero address. |
+| `value` | Amount to bridge, **excluding** fees. This is the amount credited on the destination chain. |
+| `networkFee` | Upper bound you accept for the destination-chain settlement fee. Must be ≥ the fee recomputed during execution. |
+| `exFee` | Upper bound you accept for the bridge service fee. Must be ≥ the fee recomputed during execution. |
+| `extraData` | Empty for a plain transfer, or an encoded call to execute on arrival (see [4.3](#43-extradata--bridge-and-call-in-one-step)). |
 
-```shell
-$ forge snapshot
+**Preconditions**
+
+- The bridge is not paused, the destination chain is not paused, and the token is not paused for outgoing transfers.
+- The `(toChainID, fromToken)` pair is registered.
+- `value` is non-zero and at least the minimum transfer amount (a USD-denominated floor converted to token units).
+- `networkFee` and `exFee` are each at least the corresponding fee recomputed at execution time.
+- `extraData` is within `maxExtraDataLength()` bytes (a value of `0` means unlimited).
+- When bridging a wrapped token, `value` cannot exceed the amount recorded in the bridge's local minted
+  accounting for that pair (readable from `getTokenPair`).
+
+**Fees are recomputed on-chain — this matters for how you pay**
+
+The `networkFee` and `exFee` arguments act as **upper-bound assertions**, not as the amounts charged. During
+execution the contract recomputes both fees from current prices and gas configuration, requires each argument
+to be at least the recomputed value, and then **charges and records the recomputed amounts**.
+
+| Token type | What to send |
+|---|---|
+| Native coin | `msg.value` must equal `value` **plus the fees recomputed at execution time** — an exact match. Padding `msg.value` with a safety margin reverts. |
+| ERC20 | `msg.value == 0`. The allowance consumed at execution is `value` + the **recomputed** fees. Approving your upper bounds (`value + networkFee + exFee`) tolerates a fee increase, but any unused approval remains. |
+
+Integration guidance:
+
+- Quote immediately before submitting ([4.2](#42-quoting-fees-before-you-send)).
+- For **native** transfers, if the fees recomputed at execution time differ from what you funded in `msg.value`,
+  the transaction reverts. That is a safe failure — no funds move — but expect to retry with a fresh quote. Do
+  not add a margin to `msg.value`.
+- For **ERC20** transfers, choose the fee upper bounds deliberately: they set the maximum you accept, and if you
+  approve exactly `value + networkFee + exFee` they also become the basis of the allowance you grant. Because
+  only the recomputed amount is pulled, a padded approval leaves residual allowance to the bridge — reset or
+  revoke it after a successful transfer if you do not intend a standing approval.
+
+**Result** — the call emits `BridgeInitiated` containing the assigned `index`, the paired destination token,
+the recipient, the amount, and the **recomputed** fees. That `index` is the identifier used to track
+settlement on the destination chain. Fees are transferred out immediately and are not refundable once the
+transfer starts.
+
+### 4.2 Quoting fees before you send
+
+Quotes are read from `BridgeVerifier`, whose address is available as `bridge.bridgeVerifier()`.
+
+```solidity
+// Minimum transfer amount and the two fee components for a given amount
+function calculateFee(uint remoteChainID, IERC20 token, uint value)
+    external view returns (uint minimumValue, uint networkFee, uint exFee);
+
+// Same, but returns the effective exchange-fee rate instead of the computed fee
+function getTokenConfig(uint remoteChainID, IERC20 token)
+    external view returns (uint minimumValue, uint networkFee, uint exFeeRate);
 ```
 
-### Anvil
+| Component | Meaning |
+|---|---|
+| `minimumValue` | The verifier's computed minimum for this token, derived from a USD floor. If the token has no published price the configured default price is used; if that effective price is zero the minimum falls back to one whole token. It can also be `0` for high-priced tokens — independently of this, `bridgeToken` always rejects a `value` of `0`. |
+| `networkFee` | Estimated cost of the destination-chain settlement, expressed in the bridged token. |
+| `exFee` | Proportional service fee: `value × exFeeRate / denominator()`, where `denominator()` is `10000`. |
+| `exFeeRate` | The **effective** rate actually applied — already resolved from the token-specific rate, the default rate, or a configured exemption. |
 
-```shell
-$ anvil
+`networkFee` tracks destination gas configuration and token prices, so quotes change over time. The same
+values are recomputed inside `bridgeToken`, which is why the payment rules in [4.1](#41-bridgetoken--start-a-transfer)
+are strict for native transfers.
+
+### 4.3 `extraData` — bridge and call in one step
+
+`extraData` lets a transfer trigger a call on the destination chain in the same settlement transaction —
+for example bridging tokens and staking them for the recipient.
+
+```
+extraData = target (20 bytes) || selector (4 bytes) || abi-encoded arguments
 ```
 
-### Deploy
+- `target` must be **whitelisted** on the destination chain's `BridgeExecutor`. A target may additionally be
+  restricted to specific function selectors; check `isMethodCheckEnabled(target)` to know whether selector
+  filtering applies, then `isWhitelistedMethod(target, selector)`.
+- The bridged amount is made available to the target; whatever the target does not consume is sent to `to`.
+- `extraData` is part of the signed payload, so it cannot be altered between the two chains.
 
-```shell
-$ forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
+Fallback behaviour:
+
+| Situation | Result |
+|---|---|
+| `extraData` shorter than 24 bytes, no executor configured, target not whitelisted, or the pre-call ERC20 approval to the executor fails | Plain payout to `to`. No `ExtraCallExecuted` event is emitted. |
+| Whitelisted target, call succeeds | Target consumes what it needs, remainder goes to `to`. `ExtraCallExecuted` emitted with `success = true`. |
+| Whitelisted target, call fails | Plain payout to `to` is attempted instead. `ExtraCallExecuted` emitted with `success = false`. |
+| Plain payout reports a recognized transfer or mint failure | The transfer is held for review ([4.5](#45-held-pending-transfers-and-releasepending)). Unexpected failures revert instead, as described in [4.4](#44-finalizebridgebatch--settlement-on-the-destination-chain). |
+
+A failed composed call therefore does not lose funds: the transfer degrades to a plain payout, or to a held
+transfer that can be retried. Whitelisting is performed by the `BridgeExecutor` administrators — contact them
+to have an integration target registered.
+
+### 4.4 `finalizeBridgeBatch` — settlement on the destination chain
+
+```solidity
+function finalizeBridgeBatch(
+    FinalizeArguments[] calldata args,
+    uint8[][] memory v,
+    bytes32[][] memory r,
+    bytes32[][] memory s
+) external payable returns (bool);
 ```
 
-### Cast
+Users normally never call this — the validator network submits it automatically. It is documented because it
+is **permissionless**: anyone holding a valid set of validator signatures can submit a settlement.
 
-```shell
-$ cast <subcommand>
+Requirements for a submission to be accepted:
+
+- The bridge is not paused, the source-chain entry is not paused, and each `toToken` is registered for its
+  `fromChainID`.
+- For each entry, `index` must be exactly the next expected index for that source chain
+  (`getNextFinalizeIndex(fromChainID)`).
+- `v`, `r`, `s` must each have the same length as `args`, and within an entry the three signature arrays must
+  have equal length.
+- Each entry must allow at least `threshold()` authorized signers to be counted in **strictly ascending
+  signer-address order**. Recovered addresses that are duplicated, do not hold the validator role, or are not
+  ascending are simply not counted — so always submit signatures sorted by signer address. A malformed
+  signature makes the call revert.
+- `msg.value` must be zero.
+
+Signatures are EIP-712 over:
+
+```
+FinalizeBridge(uint256 fromChainID,uint256 index,address toToken,address to,uint256 value,bytes extraData)
 ```
 
-### Help
+with domain name `Validator`, version `1.0.0`, the destination chain ID, and the destination bridge address as
+`verifyingContract` (readable as `domainSeparator()`). A signature therefore cannot be reused against a
+different destination chain ID or verifying contract.
 
-```shell
-$ forge --help
-$ anvil --help
-$ cast --help
+If any entry fails these requirements the **whole batch reverts**.
+
+An entry that passes verification but hits a value limit, or whose payout fails in a **recognized** way — the
+recipient call, ERC20 transfer, or mint reports failure — is accepted and **held for review**. That is a normal
+outcome, not a batch failure. **Unexpected** conditions are different: for example an insufficient native
+balance in the bridge or an accounting inconsistency reverts the whole batch instead of producing a held
+transfer, leaving the expected index unchanged.
+
+### 4.5 Held (pending) transfers and `releasePending`
+
+A settlement that passes signature verification but cannot be paid out for a recognized reason is **held**
+rather than lost. Common reasons are safety limits (an unusually large single transfer, or unusually high volume within a
+time window), a paused token, or a recipient that rejects the transfer.
+
+`BridgePending` is emitted with a status describing the reason:
+
+| Status | Meaning |
+|---|---|
+| `TokenPaused` | Incoming transfers for that token are paused. |
+| `VerificationAmountThresholdExceeded` | Single-transfer value limit exceeded. |
+| `PeriodTotalValueThresholdExceeded` | Rolling time-window volume limit exceeded. |
+| `TransferFailed` / `MintFailed` | Payout to the recipient failed. |
+| `CrossSupplyLimitExceeded` | Cross chain native supply cap would be exceeded. |
+| `TokenScoreOverflow` / `TokenCurrentVolumeOverflow` | Value could not be evaluated safely. |
+
+```solidity
+function releasePending(uint remoteChainID, uint index) external;
 ```
+
+`releasePending` is callable by **anyone** and retries the payout. It succeeds when:
+
+- the bridge is not paused, the source-chain entry is not paused, and incoming transfers for the token are not
+  paused;
+- the review delay stored on the held record has expired (`delayExpiration`, `0` meaning no delay);
+- the payout itself succeeds.
+
+The single-transfer and time-window value limits are **not** re-evaluated on retry — they were already
+evaluated when the transfer was first accepted. On the Cross chain, the native supply cap **is** re-checked.
+
+Composed `extraData` calls are never re-executed on a retry; a held transfer always pays out plainly.
+
+**Privileged resolution.** `VERIFIER_ROLE` can force-release a held transfer, bypassing pause, delay and limit
+checks, and can redirect the payout to a different recipient — this is the recovery path when the original
+recipient permanently rejects funds. `ADMIN_ROLE` can remove a held record without paying out. These are
+trusted-governance powers; see [§6](#6-security-and-trust-model).
+
+Inspect a held transfer with `getPendingArguments(remoteChainID, index)` and list all held indices with
+`allPendingIndex(remoteChainID)`. The review delay is initialized to 24 hours but is administrator-configurable,
+so read `delayExpiration` from the record rather than assuming a fixed value.
+
+### 4.6 Read-only functions for tracking
+
+On the bridge contract:
+
+| Function | Returns |
+|---|---|
+| `allChainIDs()` | Every remote chain ID registered on this bridge |
+| `allTokenPairs(remoteChainID)` | All token pairs for a remote chain, including local supply accounting |
+| `getTokenPair(remoteChainID, token)` | Pair details: counterpart token, origin flag, paused flag, locked/minted amounts |
+| `getNextInitiateIndex(remoteChainID)` | Index that the next outgoing transfer will receive |
+| `getNextFinalizeIndex(remoteChainID)` | Index that will be accepted next for that source chain |
+| `allPendingIndex(remoteChainID)` / `getPendingArguments(remoteChainID, index)` | Held transfers and their stored arguments, status, and `delayExpiration` |
+| `isTokenFinalizePaused(remoteChainID, token)` | Whether incoming transfers of a token are paused |
+| `maxExtraDataLength()` | Maximum `extraData` size (`0` = unlimited) |
+| `threshold()` / `domainSeparator()` | Multi-signature threshold and EIP-712 domain separator of this bridge |
+| `paused()` | Global pause state |
+
+On `BridgeVerifier`:
+
+| Function | Returns |
+|---|---|
+| `calculateFee(chainID, token, value)` | `(minimumValue, networkFee, exFee)` |
+| `getTokenConfig(chainID, token)` | `(minimumValue, networkFee, effective exFeeRate)` |
+| `getTokenPrice(token)` | `(exist, price)`. When `exist == false` the returned price is the configured fallback price, not a live quote. |
+| `getMinimumTokenValue()` | USD floor, expressed with the price feed's dollar precision |
+| `denominator()` | `10000`, the denominator for fee rates |
+
+To follow a transfer end to end: take `index` from `BridgeInitiated` on the source chain, then watch for
+`BridgeFinalized` or `BridgePending` with the same `(fromChainID, index)` on the destination chain.
+
+When you build that tracking, keep two identities apart:
+
+- **Raw log identity**, for discarding logs you already processed: (chain ID, transaction hash, log index).
+- **Logical transfer identity**, for correlating the two chains: (chain ID, bridge address, **direction**,
+  remote chain ID, `index`). The remote chain ID is `toChainID` in `BridgeInitiated` and `fromChainID` in
+  `BridgeFinalized` / `BridgePending`. Direction matters because outgoing and incoming indices are counted
+  independently, so the same `(remote chain ID, index)` can exist in both directions on one bridge.
+
+Also treat logs as revertible and states as non-final: wait for whatever finality your integration requires
+before showing a transfer as complete, handle logs removed by a chain reorganization, and remember that
+`BridgePending` is **not** terminal — the same transfer can later emit `BridgeFinalized` when it is released, or
+`PendingRemoved` if it is dropped without payout.
+
+### 4.7 Chain-specific and auxiliary entry points
+
+**Cross chain — native supply cap.** The amount of native CROSS that may be paid out by the bridge is bounded
+by a configurable cap, readable via `crossSupply()` and `crossSupplyLimit()`. A settlement that would exceed
+it is held with `CrossSupplyLimitExceeded`. The cap applies to automatic settlement and to public retries; a
+privileged manual release bypasses it.
+
+**BSC — coordinated burn.**
+
+```solidity
+function burnCrossToDeadWallet(address deadWallet, uint amount, bool alreadyTransferred) external returns (bool);
+```
+
+With `alreadyTransferred = false` any holder may burn CROSS and have the burn reflected on the Cross chain.
+Conditions: the bridge is not paused, `amount` is non-zero, `deadWallet` is one of the pre-approved burn
+addresses, and the caller has approved the bridge to spend `amount` of the configured CROSS token.
+
+With `alreadyTransferred = true` no token transfer happens on BSC — the caller asserts that the tokens were
+already sent to the burn address, and the initiation event is emitted with the bridge itself as the source.
+That variant is restricted to `ADMIN_ROLE`.
+
+**`permitBridgeTokenBatch` — relayer entry point.**
+
+```solidity
+function permitBridgeTokenBatch(BridgeTokenArguments[] calldata args, PermitArguments[] calldata permitArgs) external payable;
+```
+
+Starts transfers from EIP-2612 permit signatures instead of prior approvals. It is restricted to holders of
+`INITIATOR_ROLE` so that transfer parameters cannot be injected by a third party using a captured permit.
+
+| Struct | Fields |
+|---|---|
+| `BridgeTokenArguments` | `toChainID`, `fromToken`, `from`, `to`, `value`, `networkFee`, `exFee`, `extraData` — same meaning as the `bridgeToken` arguments. **`from` is ignored here**: the funds always come from `permitArgs.account`. |
+| `PermitArguments` | `token`, `account`, `value`, `deadline`, `v`, `r`, `s` — a standard EIP-2612 permit granting the **bridge** an allowance. |
+
+Conditions: `args.length == permitArgs.length`; for each entry `permitArgs.token` equals `fromToken`, `to`
+equals `permitArgs.account`, the permit is valid and unexpired, and `permitArgs.value` covers `value` plus the
+fees recomputed at execution time; each pair must be registered and active. `permitArgs.value` becomes the
+bridge's allowance, so any part not consumed remains approved.
+
+The shared pause, registration, minimum-amount, fee, wrapped-supply and `extraData` conditions from
+[4.1](#41-bridgetoken--start-a-transfer) apply to every entry. This entry point works only with ERC20 tokens
+that implement EIP-2612 permit compatibly — the native-coin sentinel cannot be used here. The batch is
+**atomic**: one failing entry reverts every entry. Never send value with this call: a non-empty batch requires
+`msg.value == 0`, and value sent alongside an empty batch simply stays in the bridge.
+
+**`SwapBridgeRouter` — swap and bridge in one transaction.**
+
+An optional helper that swaps on a Uniswap V3 market and immediately starts a bridge transfer with the output.
+Eight entry points combine three choices: exact-input vs exact-output, single-pool vs multi-hop path, and ERC20
+vs native input. Every entry point takes a params struct plus a `deadline`.
+
+| Entry point | Path form | Input | Required `msg.value` |
+|---|---|---|---|
+| `swapBridgeExactInputSingle` | single pool | ERC20 | `0` |
+| `swapBridgeExactInput` | multi-hop `path` | ERC20 | `0` |
+| `swapBridgeExactOutputSingle` | single pool | ERC20 | `0` |
+| `swapBridgeExactOutput` | multi-hop `path` | ERC20 | `0` |
+| `swapBridgeExactInputSingleETH`, `swapBridgeExactInputETH` | as above | native coin | exactly `amountIn` |
+| `swapBridgeExactOutputSingleETH`, `swapBridgeExactOutputETH` | as above | native coin | at least `amountInMaximum` |
+
+Parameters:
+
+| Field | Used by | Meaning |
+|---|---|---|
+| `tokenIn`, `tokenOut` | single-pool variants | Input and output token. In the ETH variants `tokenIn` must be the wrapped native token. |
+| `fee` | single-pool variants | Uniswap V3 fee tier identifying the pool. |
+| `path` | multi-hop variants | Encoded swap path: input → output for exact-input, and **reversed** (output → input) for exact-output. |
+| `amountIn` | exact-input | Input amount supplied. A `sqrtPriceLimitX96` stop can end the swap early, and the unspent remainder is refunded — so this is the amount supplied, not necessarily the amount spent. |
+| `amountOutMinimum` | exact-input | Slippage floor on the swap output, before bridge fees are deducted. |
+| `amountOut` | exact-output | Exact amount to be credited **on the destination chain**, after bridge fees. |
+| `amountInMaximum` | exact-output | Maximum input you accept; the unused part is refunded. |
+| `sqrtPriceLimitX96` | single-pool variants | Uniswap V3 price limit for the swap; `0` for no limit. |
+| `bridgeParams.toChainID` | all | Destination chain ID. |
+| `bridgeParams.recipient` | all | Recipient on the destination chain. |
+| `bridgeParams.extraData` | all | Forwarded to the bridge; same rules as [4.3](#43-extradata--bridge-and-call-in-one-step). |
+| `deadline` | all | The call reverts once this timestamp has passed. |
+
+Common rules:
+
+- ERC20 variants: approve the router for `amountIn` (exact-input) or `amountInMaximum` (exact-output) and send
+  no value.
+- Unspent input is refunded to the caller — the unused part of `amountInMaximum` on exact-output, and any
+  unspent remainder on exact-input — as the input token, or as native coin in the ETH variants. In the
+  exact-output ETH variants any `msg.value` above `amountInMaximum` is refunded as well.
+- Bridge fees are deducted from the swap output; the amount credited on the destination chain is `bridgeValue`
+  in the `SwapBridge` event, which also carries `initiateIndex` — the bridge transfer index to track as in
+  [4.6](#46-read-only-functions-for-tracking).
+- The struct declarations are in `src/interface/ISwapBridgeRouter.sol`.
+
+Quote helpers:
+
+| Helper | Input | Returns |
+|---|---|---|
+| `getAmountSwapBridgeOut(toChainID, tokenIn, tokenOut, fee, amountIn)` | input amount, single pool | `status`, `swapAmountOut`, `bridgeValue`, `networkFee`, `exFee` |
+| `getAmountSwapBridgeOutMultihop(toChainID, path, amountIn)` | input amount, multi-hop | same as above |
+| `getAmountSwapBridgeIn(toChainID, tokenIn, tokenOut, fee, bridgeValue)` | desired destination amount, single pool | `status`, `amountIn`, `swapAmountOut`, `networkFee`, `exFee` |
+| `getAmountSwapBridgeInMultihop(toChainID, path, bridgeValue)` | desired destination amount, multi-hop | same as above |
+| `getExpectedBridgeAmount(toChainID, token, totalAmount)` | amount before fees | `status`, `bridgeValue`, `networkFee`, `exFee` |
+| `calculateBridgeFees(toChainID, token, value)` | destination amount | `minimumValue`, `networkFee`, `exFee` |
+
+The four `getAmountSwapBridge*` helpers are **not** `view` — they simulate the swap through the Uniswap quoter,
+so call them off-chain. `getExpectedBridgeAmount` and `calculateBridgeFees` are `view`.
+
+`status` is a `QuoteStatus`: `Success` (1) means usable; `NoPair` (2) the token pair is not registered for that
+chain; `InsufficientForFee` (3) the amount cannot cover the network fee; `InsufficientValue` (4) the resulting
+bridge value is below the minimum; `InvalidSwap` (5) the swap could not be quoted (no pool or insufficient
+liquidity); `Invalid` (0) is the uninitialized default. Only act on `Success`.
+
+---
+
+## 5. Validator network
+
+The off-chain counterpart of these contracts is an independent validator network
+([`bridge-validator`](https://github.com/to-nexus/bridge-validator)). Its responsibilities:
+
+| Responsibility | Description |
+|---|---|
+| **Observation** | Each validator independently watches the bridge contract on every registered chain, and acts on an event only after its configured confirmation/finality policy for that chain is satisfied. |
+| **Attestation** | For each observed transfer, a validator signs an EIP-712 message bound to the destination bridge's domain. A signature attests to exactly one transfer: chain pair, index, token, recipient, amount, and `extraData`. |
+| **Coordination** | Validators do not call each other. They publish signatures to a shared, replicated coordination cluster (etcd), which also elects a single leader among the nodes. |
+| **Submission** | The elected leader submits settlement transactions in strict transfer-index order, once a transfer has reached the signature threshold. Concentrating submission in one node avoids duplicate and competing settlement transactions. |
+
+Properties that follow, and their limits:
+
+- **Settlement needs a quorum.** A signature counts only if the recovered signer currently holds the
+  validator role on-chain, and settlement requires `threshold` distinct signers. No validator can authorize a
+  payout alone unless the configured threshold is `1` — read `threshold()` to see the value in force.
+- **Validators do not hold user funds.** They only produce signatures; custody stays in the bridge contracts.
+- **Availability, not custody, is what degrades.** If fewer than `threshold` validators are available,
+  settlement stops until participation recovers. Deposits remain accounted for on-chain and settlement
+  resumes from the next expected index.
+- **Revocation takes effect on-chain.** Removing the validator role from an address invalidates its
+  signatures for future settlements.
+- **Governance is trusted.** The validator set, the threshold, contract upgrades and limits are controlled by
+  administrative roles rather than by the validator quorum — see [§6](#6-security-and-trust-model) and
+  [§8](#8-roles).
+
+Operational details of the network — deployment topology, coordination-store layout, timing and retry
+policies, and key management — are outside the scope of this document.
+
+---
+
+## 6. Security and trust model
+
+| Mechanism | Effect |
+|---|---|
+| Threshold multi-signature | Settlement requires `threshold` distinct authorized validator signatures over the exact transfer. |
+| EIP-712 domain binding | Signatures are bound to the destination chain ID and bridge address, so they cannot be reused against a different destination chain ID or verifying contract. |
+| Sequential indices | Each source-chain transfer can be accepted at most once and only in index order. A held transfer advances the index, so its payout may complete after later transfers. |
+| Local supply accounting | Each bridge tracks locked (origin) and minted (wrapped) amounts, and outgoing wrapped transfers cannot exceed the bridge's local minted accounting. The 1:1 cross-chain relationship holds as long as attestations are valid and wrapped `MINTER_ROLE` membership stays limited to the bridge. |
+| Value limits | Single-transfer and rolling-window value limits divert unusually large flows to a held state instead of paying out automatically. |
+| Native supply cap | On the Cross chain, automatic payouts and public retries of the native coin are bounded by an adjustable cap. |
+| Layered pausing | Transfers can be halted globally, per chain, or per token — independently for the outgoing and incoming direction. |
+| Safe payout | Recognized payout failures (recipient call, ERC20 transfer, or mint reporting failure) and failed composed calls degrade to a plain payout or a held transfer instead of losing funds. Unexpected conditions revert the settlement instead of producing a held transfer. |
+| Composed-call whitelisting | `extraData` can only reach targets explicitly whitelisted by the `BridgeExecutor` administrators, optionally restricted to specific function selectors. |
+| Reentrancy protection | Transfer initiation, batch settlement, held-transfer payout and composed-call execution are reentrancy-guarded. |
+
+**Trusted powers.** Users should treat the following as part of the risk model:
+
+- `DEFAULT_ADMIN_ROLE` grants and revokes every role, including the validator role, so it ultimately controls
+  who can authorize settlements.
+- The bridge's `ADMIN_ROLE` can upgrade the bridge implementation (UUPS), change the signature threshold,
+  reconfigure the review delay, replace the fee/limit and executor components, and remove a held transfer
+  without paying out.
+- `BridgeVerifier`'s and `BridgeExecutor`'s own `ADMIN_ROLE` holders — independent membership sets — control the
+  value limits and price-feed reference, and the composed-call whitelist, respectively.
+- `VERIFIER_ROLE` can force-release a held transfer, bypassing pause, delay and limit checks, and can redirect
+  the payout to a different recipient.
+- `OPERATOR_ROLE` can pause transfers globally, per chain, or per token.
+- `PRICER_ROLE` publishes the prices that drive fees and value limits.
+- Each `CrossMintableERC20V2` wrapped token has its **own** default administrator, which controls `MINTER_ROLE`
+  on that token independently of the bridge's roles. (The earlier `CrossMintableERC20` has no such
+  administrator — its minter is a single immutable bridge address.)
+
+---
+
+## 7. Contracts
+
+| Contract | Purpose |
+|---|---|
+| `BaseBridge` | Core bridge: transfer initiation, signature-verified settlement, held-transfer handling, registry and roles. Upgradeable (UUPS). |
+| `CrossBridge` | Cross-chain deployment of the bridge; adds the native CROSS supply cap. |
+| `BSCBridge` / `BSCBridgeV2` | BSC deployment of the bridge; V2 adds coordinated burn support. |
+| `BridgeVerifier` | Fee quoting and value-limit evaluation. |
+| `BridgeExecutor` | Executes whitelisted `extraData` calls during settlement. |
+| `PriceFeed` | Token and native-coin price source used for fees and limits. Upgradeable (UUPS). |
+| `CrossMintableERC20V2` | Wrapped token issued by the bridge (`ERC20` + `ERC20Permit`). |
+| `SwapBridgeRouter` | Optional swap-and-bridge router (Uniswap V3). |
+| `BridgeBot` | Optional helper contract for scheduled recurring transfers. |
+
+Supporting modules: `abstract/RoleManager` (access control), `abstract/ValidatorManager`
+(EIP-712 domain and threshold verification), `abstract/BridgeRegistry` (chains, token pairs, indices,
+held records), and `lib/` (constants, amount conversion).
+
+---
+
+## 8. Roles
+
+Access control is role-based, and roles are **scoped to the contract that exposes the protected function**.
+`BaseBridge`, `BridgeVerifier`, `PriceFeed`, `BridgeExecutor` and each wrapped token keep independent
+access-control state, so the same role name on two contracts is two different membership sets. Each contract
+also has its own administrator; the bridge's administrator does not govern the others.
+
+Enumerating members is not uniformly available: `getRoleMembers(role)` exists on the bridge, `PriceFeed` and
+`BridgeVerifier`, while `BridgeExecutor` and `CrossMintableERC20V2` expose only `hasRole` plus
+`RoleGranted` / `RoleRevoked` events, so their full membership must be reconstructed from event history.
+
+| Role | Contract | Capability |
+|---|---|---|
+| `DEFAULT_ADMIN_ROLE` | Bridge | Grants and revokes every bridge role below, including `VALIDATOR_ROLE`. Assigned to the deployment owner at initialization. |
+| `ADMIN_ROLE` | Bridge | Contract upgrades, threshold changes, component wiring, review-delay configuration, removing a held record |
+| | Verifier | Value-limit and time-window configuration, settlement-gas assumption, price-feed replacement |
+| | Executor | Target/selector whitelist, return-data limit, stuck-asset recovery |
+| `VALIDATOR_ROLE` | Bridge | Signatures counted toward the settlement threshold |
+| `OPERATOR_ROLE` | Bridge | Pausing globally, per chain, or per token |
+| `EDITOR_ROLE` | Bridge | Registering token pairs, `extraData` size limit |
+| | Verifier | Exchange-fee rates, default price, minimum transfer value |
+| `VERIFIER_ROLE` | Bridge | Force-releasing held transfers, redirecting a payout, adjusting a review window |
+| `PRICER_ROLE` | PriceFeed | Publishing token and native-coin prices |
+| | Verifier | Publishing destination-chain gas prices |
+| `INITIATOR_ROLE` | Bridge | Submitting permit-based batched transfers |
+| `EXECUTOR_ROLE` | Executor | Executing composed `extraData` calls — held by the bridge |
+| `MINTER_ROLE` | Wrapped token | Minting and burning. Granted to the bridge at creation; in `CrossMintableERC20V2` it is administered by that token's own default administrator |
+
+---
+
+## 9. Events
+
+| Event | Emitted when |
+|---|---|
+| `BridgeInitiated` | A transfer is started on the source chain (carries the transfer `index` and the charged fees) |
+| `BridgeFinalized` | A transfer is paid out on the destination chain |
+| `BridgePending` | A transfer is held, with a status describing the reason |
+| `ExtraCallExecuted` | A composed `extraData` call was attempted, successfully or not |
+| `ManualReleased` / `PendingRemoved` / `VerificationDelayExpirationSet` | A held transfer was force-resolved, removed, or its review window changed |
+| `ThresholdChanged` | The multi-signature threshold changed |
+| `TokenPairRegistered` / `TokenPauseSet` / `ChainPauseSet` | Registry or availability changed |
+| `PriceUpdated` / `NativeTokenPriceUpdated` / `GasPriceUpdated` / `ExchangeFeeUpdated` | Pricing or fee configuration changed |
+
+---
+
+## 10. Build and test
+
+Built with [Foundry](https://book.getfoundry.sh/). Dependencies are git submodules.
+
+```bash
+git submodule update --init --recursive
+forge build
+forge test
+forge test --match-contract BridgeExecutorTest -vvv
+forge test --gas-report
+forge fmt
+```
+
+Notes:
+
+- The default profile compiles with the IR pipeline, which is slow but keeps contracts within the size limit.
+- An alternative profile is available for the BSC V2 bridge: `FOUNDRY_PROFILE=v2 forge build`.
+- Import paths are resolved through `remappings.txt`.
+
+The test suite covers round-trip transfers, registry and permission behaviour, revert and held-transfer edge
+cases, composed `extraData` execution and fallback, value-limit monitoring, the native supply cap, signature
+and threshold verification, wrapped tokens, the swap router, and gas measurements.
+
+---
+
+## 11. Go bindings
+
+`binding/go` contains generated Go bindings (`abigen`) published as a separate module:
+
+```
+module github.com/to-nexus/bridge-contracts/binding/go
+
+import "github.com/to-nexus/bridge-contracts/binding/go/src"   // package binding
+```
+
+They are the integration surface used by the validator network and can be imported by any Go client that needs
+typed access to the bridge ABI and events — contract constructors, typed event structs such as
+`BaseBridgeBridgeInitiated`, and log filterers/parsers. The files are generated output and are regenerated when
+the contract ABIs change, so pin a version that matches the deployment you target.
+
+---
+
+## 12. License
+
+MIT

--- a/README_KO.md
+++ b/README_KO.md
@@ -1,0 +1,660 @@
+# Cross Bridge Contracts
+
+**Cross Bridge** 스마트 컨트랙트 — Cross 체인과 BSC 등 외부 EVM 체인 사이에서 토큰을 이동시키는
+멀티시그 기반 크로스체인 브리지입니다.
+
+English: [README.md](README.md)
+
+---
+
+## 목차
+
+- [1. 개요](#1-개요)
+- [2. 전송 흐름](#2-전송-흐름)
+- [3. 토큰 모델](#3-토큰-모델)
+- [4. 사용자 API](#4-사용자-api)
+  - [4.1 `bridgeToken` — 전송 시작](#41-bridgetoken--전송-시작)
+  - [4.2 전송 전 수수료 조회](#42-전송-전-수수료-조회)
+  - [4.3 `extraData` — 전송과 동시에 호출](#43-extradata--전송과-동시에-호출)
+  - [4.4 `finalizeBridgeBatch` — 목적지 체인 정산](#44-finalizebridgebatch--목적지-체인-정산)
+  - [4.5 보류된 전송과 `releasePending`](#45-보류된-전송과-releasepending)
+  - [4.6 조회용 함수](#46-조회용-함수)
+  - [4.7 체인별 및 부가 진입점](#47-체인별-및-부가-진입점)
+- [5. Validator 네트워크](#5-validator-네트워크)
+- [6. 보안과 신뢰 모델](#6-보안과-신뢰-모델)
+- [7. 컨트랙트](#7-컨트랙트)
+- [8. 역할](#8-역할)
+- [9. 이벤트](#9-이벤트)
+- [10. 빌드와 테스트](#10-빌드와-테스트)
+- [11. Go 바인딩](#11-go-바인딩)
+- [12. 라이선스](#12-라이선스)
+
+---
+
+## 1. 개요
+
+이 브리지는 체인 간에 메시지를 중계하는 방식이 아닙니다.
+
+1. 사용자가 **출발 체인**에서 토큰을 예치(또는 소각)하면 `BridgeInitiated` 이벤트가 발생합니다.
+2. 오프체인 **validator 네트워크**가 이 이벤트를 관측하고, 각 validator가 전송 내용에 대해
+   EIP-712 서명을 생성합니다.
+3. 서명이 충분히 모이면 **목적지 체인**에 정산 트랜잭션이 제출되고, 브리지 컨트랙트가 서명을 검증한 뒤
+   수신자에게 지급합니다.
+
+모든 전송에는 체인쌍 단위로 **단조 증가하는 인덱스**가 부여되며, 목적지 체인은 다음에 처리해야 할 인덱스만
+받아들입니다. 따라서 정산의 재실행·건너뛰기·순서 변경이 불가능합니다. 단, 접수되었지만 검토를 위해 보류된
+전송도 인덱스를 소비하므로, 그 지급은 이후 전송보다 늦게 완료될 수 있습니다.
+
+정산 권한 모델은 **`threshold`-of-`N` 멀티시그**입니다. 컨트랙트는 현재 validator 역할을 보유한 서로 다른
+주소가 "정산하려는 그 전송"에 충분히 서명했는지를 검증합니다. 역할 구성, 임계값, 업그레이드, 한도 등
+거버넌스는 별도로 관리됩니다 — [§6](#6-보안과-신뢰-모델) 참고.
+
+---
+
+## 2. 전송 흐름
+
+```mermaid
+graph LR
+    subgraph SRC["출발 체인"]
+        U["사용자 / 라우터 / 컨트랙트"]
+        SB["Bridge"]
+        U -->|"bridgeToken(...)"| SB
+    end
+
+    VN["Validator 네트워크<br/>(오프체인, threshold-of-N)"]
+
+    subgraph DST["목적지 체인"]
+        DB["Bridge"]
+        R["수신자"]
+        X["화이트리스트 대상 컨트랙트<br/>(선택, extraData)"]
+        DB --> R
+        DB -.-> X
+    end
+
+    SB -.->|"BridgeInitiated 이벤트"| VN
+    VN -->|"서명이 담긴 정산 트랜잭션"| DB
+```
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User as 사용자
+    participant SB as 출발 브리지
+    participant VN as Validator 네트워크
+    participant DB as 목적지 브리지
+
+    User->>SB: bridgeToken(toChainID, token, to, value, networkFee, exFee, extraData)
+    SB->>SB: 토큰 예치 또는 소각 + 재계산된 수수료 징수
+    SB-->>User: BridgeInitiated(toChainID, index, ...)
+    SB-->>VN: 이벤트 관측
+    VN->>VN: 각 validator가 전송 내용에 EIP-712 서명
+    VN->>DB: finalizeBridgeBatch(args, signatures)
+    DB->>DB: 서명·기대 인덱스·안전 한도 검증
+    alt 한도 내 + 지급 성공
+        DB->>User: `to` 에게 토큰 전송 또는 발행
+        DB-->>VN: BridgeFinalized
+    else 한도 초과 또는 인지된 지급 실패
+        DB->>DB: 검토를 위해 보류
+        DB-->>VN: BridgePending(status)
+    end
+```
+
+---
+
+## 3. 토큰 모델
+
+브리지 가능한 토큰은 로컬 토큰과 상대 체인의 대응 토큰이 **한 쌍(pair)** 으로 등록됩니다.
+한쪽은 실제 토큰이 존재하는 **origin** 체인이고, 다른 쪽은 브리지가 발행하는 **wrapped** 토큰을 보유합니다.
+
+| 방향 | 출발 체인 | 목적지 체인 |
+|---|---|---|
+| origin → wrapped | 토큰이 브리지에 **잠김(lock)** | wrapped 토큰이 수신자에게 **발행(mint)** |
+| wrapped → origin | wrapped 토큰이 **소각(burn)** | 잠겨 있던 원본 토큰이 **지급(release)** |
+
+사용자 관점의 함의:
+
+- 브리지 정산은 임계값 서명 검증을 통과한 뒤에만 wrapped 토큰을 발행합니다. 각 브리지는 자신의 잠김·발행
+  수량을 로컬 회계로 관리하며, wrapped 토큰의 출금은 해당 브리지의 로컬 발행 회계에 남아 있는 수량을 초과할
+  수 없습니다.
+- wrapped 토큰의 발행 권한은 **별도의 신뢰 경계**입니다. 구현이 두 종류이므로 해당 페어가 실제로 어느 것을
+  쓰는지 확인하세요. `CrossMintableERC20V2`는 토큰 생성 시 브리지에 `MINTER_ROLE`을 부여하지만, 그 토큰의
+  자체 기본 관리자가 다른 주소에도 이 역할을 부여할 수 있고, 추가 발행자가 생기면 토큰의 실제 공급량이
+  브리지 회계와 어긋나게 됩니다. V2는 구성원 열거 함수를 제공하지 않으므로 1:1 관계에 의존한다면 배포 이후의
+  `RoleGranted` / `RoleRevoked` 이력으로 구성원을 재구성하고 개별 주소는 `hasRole`로 확인하세요.
+  이전 버전인 `CrossMintableERC20`은 불변 브리지 주소만을 유일한 발행·소각 권한자로 고정합니다.
+- **토큰 호환성은 가정이며 강제되지 않습니다.** 브리지는 실제로 수령한 잔액을 측정하지 않고 요청한 명목
+  `value`를 기록합니다. 따라서 등록되는 origin 토큰은 요청한 수량을 정확히 이전하고 잔액이 임의로 변하지 않아야
+  합니다. fee-on-transfer와 rebasing 동작은 브리지 회계와 실제 보관량을 직접 어긋나게 만들며, 콜백을 수행하거나
+  비표준인 토큰은 별도의 호환성·재진입 검토가 필요합니다. 어느 경우도 지원된다고 가정하면 안 됩니다.
+- 네이티브 코인(CROSS, BNB, ETH 등)은 토큰 인자 자리에 예약 주소 `0x00...01`(`Const.NATIVE_TOKEN`)로
+  표현합니다.
+- wrapped 토큰은 브리지가 배포하는 표준 `ERC20` + `ERC20Permit` 컨트랙트로, 이름은 `Cross Bridge <SYMBOL>`,
+  심볼은 `<SYMBOL>x`이며 **등록 시 전달된** 심볼과 decimals를 사용합니다. 원본 토큰과 동일하다고 가정하지 말고
+  토큰의 `decimals()`를 직접 조회하세요.
+- **등록된 페어**만 전송할 수 있습니다. 해당 배포에서 지원되는 조합은 `allChainIDs()` / `allTokenPairs()` /
+  `getTokenPair()`로 확인하세요.
+
+---
+
+## 4. 사용자 API
+
+### 4.1 `bridgeToken` — 전송 시작
+
+일반 사용자의 유일한 진입점이며, **출발 체인**에서 호출합니다.
+
+```solidity
+function bridgeToken(
+    uint toChainID,
+    IERC20 fromToken,
+    address to,
+    uint value,
+    uint networkFee,
+    uint exFee,
+    bytes calldata extraData
+) external payable returns (bool);
+```
+
+| 인자 | 설명 |
+|---|---|
+| `toChainID` | 목적지 체인 ID. `fromToken`에 대해 페어가 등록된 체인이어야 합니다. |
+| `fromToken` | **출발 체인에서** 보낼 토큰. 네이티브 코인은 `0x00...01`. |
+| `to` | 목적지 체인의 수신자 주소. 0 주소는 사용할 수 없습니다. |
+| `value` | 브리지할 수량. **수수료 제외** 금액이며, 목적지 체인에서 수신자가 받는 금액입니다. |
+| `networkFee` | 목적지 체인 정산 수수료로 수용할 **상한**. 실행 시점에 재계산된 수수료 이상이어야 합니다. |
+| `exFee` | 브리지 이용 수수료로 수용할 **상한**. 실행 시점에 재계산된 수수료 이상이어야 합니다. |
+| `extraData` | 단순 전송이면 빈 값. 도착과 동시에 실행할 호출을 담을 수 있습니다([4.3](#43-extradata--전송과-동시에-호출)). |
+
+**충족해야 하는 조건**
+
+- 브리지 전체가 정지 상태가 아니고, 목적지 체인이 정지 상태가 아니며, 해당 토큰의 출금(전송 시작)이
+  정지되어 있지 않아야 합니다.
+- `(toChainID, fromToken)` 페어가 등록되어 있어야 합니다.
+- `value`가 0이 아니고 최소 전송 금액 이상이어야 합니다(달러 기준 하한을 토큰 수량으로 환산한 값).
+- `networkFee`, `exFee`가 각각 실행 시점에 재계산된 수수료 이상이어야 합니다.
+- `extraData` 길이가 `maxExtraDataLength()` 이내여야 합니다(`0`이면 무제한).
+- wrapped 토큰을 보낼 때는 `value`가 해당 페어의 브리지 로컬 발행 회계에 기록된 수량을 초과할 수 없습니다
+  (`getTokenPair`로 조회).
+
+**수수료는 온체인에서 재계산됩니다 — 지불 방식에 직접 영향**
+
+`networkFee`와 `exFee` 인자는 실제 징수액이 아니라 **상한 선언**입니다. 실행 중 컨트랙트가 현재 가격과 가스
+설정으로 두 수수료를 다시 계산하고, 전달된 인자가 재계산값 이상인지 확인한 뒤 **재계산된 금액을 징수·기록**합니다.
+
+| 토큰 종류 | 전달해야 하는 값 |
+|---|---|
+| 네이티브 코인 | `msg.value`가 `value` + **실행 시점 재계산 수수료**와 **정확히 일치**해야 합니다. 여유분을 더해 보내면 revert됩니다. |
+| ERC20 | `msg.value == 0`. 실행 시 소모되는 allowance는 `value` + **재계산된** 수수료입니다. 상한(`value + networkFee + exFee`)으로 approve하면 수수료 상승을 견딜 수 있지만, 사용되지 않은 승인은 남습니다. |
+
+연동 가이드:
+
+- 제출 직전에 수수료를 조회하세요([4.2](#42-전송-전-수수료-조회)).
+- **네이티브** 전송은 실행 시점에 재계산된 수수료가 `msg.value`로 충당한 금액과 다르면 revert됩니다.
+  자금이 이동하지 않는 안전한 실패이므로, 새로 조회해 재시도하면 됩니다. `msg.value`에 여유분을 더하지 마세요.
+- **ERC20** 전송은 수수료 상한을 신중히 정하세요. 이 값은 수용 한도이며, `value + networkFee + exFee`를 그대로
+  approve한다면 부여하는 allowance의 기준이 되기도 합니다. 재계산된 금액만 인출되므로 여유를 둔 approve는
+  브리지에 잔여 allowance를 남깁니다. 상시 승인을 의도하지 않는다면 전송 성공 후 잔여 승인을 되돌리거나
+  회수하세요.
+
+**결과** — 호출이 성공하면 배정된 `index`, 목적지 토큰, 수신자, 수량, **재계산된** 수수료를 담은
+`BridgeInitiated` 이벤트가 발생합니다. 이 `index`가 목적지 체인에서 정산을 추적하는 식별자입니다.
+수수료는 즉시 이전되며 전송이 시작된 뒤에는 환불되지 않습니다.
+
+### 4.2 전송 전 수수료 조회
+
+조회는 `BridgeVerifier`에서 수행하며, 주소는 `bridge.bridgeVerifier()`로 얻을 수 있습니다.
+
+```solidity
+// 최소 전송 금액과 특정 수량에 대한 두 가지 수수료
+function calculateFee(uint remoteChainID, IERC20 token, uint value)
+    external view returns (uint minimumValue, uint networkFee, uint exFee);
+
+// 동일하지만 계산된 수수료 대신 실효 교환 수수료 요율을 반환
+function getTokenConfig(uint remoteChainID, IERC20 token)
+    external view returns (uint minimumValue, uint networkFee, uint exFeeRate);
+```
+
+| 항목 | 의미 |
+|---|---|
+| `minimumValue` | 달러 기준 하한에서 환산된, verifier가 계산한 최소값. 토큰 가격이 등록되어 있지 않으면 설정된 기본 가격을 사용하고, 그 실효 가격이 0이면 1 토큰으로 대체됩니다. 단가가 높은 토큰에서는 `0`이 될 수도 있습니다. 이와 별개로 `bridgeToken`은 `value == 0`을 항상 거부합니다. |
+| `networkFee` | 목적지 체인 정산 비용 추정치를 브리지 대상 토큰으로 환산한 값. |
+| `exFee` | 비례 수수료: `value × exFeeRate / denominator()`, `denominator()`는 `10000`. |
+| `exFeeRate` | 실제로 적용되는 **실효 요율**. 토큰별 요율, 기본 요율, 면제 설정이 이미 반영된 값입니다. |
+
+`networkFee`는 목적지 체인의 가스 설정과 토큰 가격을 반영하므로 시간에 따라 변합니다. 같은 값이
+`bridgeToken` 내부에서 다시 계산되기 때문에 [4.1](#41-bridgetoken--전송-시작)의 네이티브 지불 규칙이 엄격합니다.
+
+### 4.3 `extraData` — 전송과 동시에 호출
+
+`extraData`를 사용하면 정산 트랜잭션 안에서 목적지 체인의 컨트랙트를 함께 호출할 수 있습니다.
+예를 들어 토큰을 브리지하면서 수신자 명의로 스테이킹까지 한 번에 처리할 수 있습니다.
+
+```
+extraData = target (20 bytes) || selector (4 bytes) || abi 인코딩된 인자
+```
+
+- `target`은 목적지 체인의 `BridgeExecutor`에 **화이트리스트로 등록**되어 있어야 합니다. 대상별로 특정 함수
+  selector만 허용할 수도 있으므로, `isMethodCheckEnabled(target)`으로 selector 검사 적용 여부를 먼저 확인한 뒤
+  `isWhitelistedMethod(target, selector)`를 조회하세요.
+- 브리지된 수량이 대상 컨트랙트에 제공되며, 대상이 사용하지 않은 잔액은 `to`에게 전달됩니다.
+- `extraData`는 서명 대상에 포함되므로 두 체인 사이에서 변경될 수 없습니다.
+
+폴백 동작:
+
+| 상황 | 결과 |
+|---|---|
+| `extraData`가 24바이트 미만, executor 미설정, 대상이 화이트리스트에 없음, 또는 executor에 대한 사전 ERC20 approve 실패 | `to`에게 단순 지급. `ExtraCallExecuted` 이벤트는 발생하지 않습니다. |
+| 화이트리스트 대상, 호출 성공 | 대상이 필요한 만큼 사용하고 잔액은 `to`에게. `ExtraCallExecuted`(`success = true`) 발생. |
+| 화이트리스트 대상, 호출 실패 | 대신 `to`에게 단순 지급 시도. `ExtraCallExecuted`(`success = false`) 발생. |
+| 단순 지급이 인지된 전송·발행 실패를 보고 | 전송이 보류됩니다([4.5](#45-보류된-전송과-releasepending)). 예상치 못한 실패는 [4.4](#44-finalizebridgebatch--목적지-체인-정산)에서 설명한 대로 revert됩니다. |
+
+즉 결합 호출 실패는 자산 손실로 이어지지 않습니다. 단순 지급으로 격하되거나, 재시도 가능한 보류 상태가
+됩니다. 화이트리스트 등록은 `BridgeExecutor` 관리자가 수행하므로 연동 대상 등록은 해당 관리자에게 요청하세요.
+
+### 4.4 `finalizeBridgeBatch` — 목적지 체인 정산
+
+```solidity
+function finalizeBridgeBatch(
+    FinalizeArguments[] calldata args,
+    uint8[][] memory v,
+    bytes32[][] memory r,
+    bytes32[][] memory s
+) external payable returns (bool);
+```
+
+사용자가 직접 호출할 일은 없습니다. validator 네트워크가 자동으로 제출합니다. 다만 이 함수는
+**permissionless**이므로, 유효한 validator 서명 묶음을 가진 누구든 정산을 제출할 수 있어 문서화합니다.
+
+제출이 받아들여지기 위한 조건:
+
+- 브리지가 정지 상태가 아니고, 해당 출발 체인 항목이 정지 상태가 아니며, 각 `toToken`이 그 `fromChainID`에
+  대해 등록되어 있어야 합니다.
+- 각 항목의 `index`가 해당 출발 체인의 다음 기대 인덱스(`getNextFinalizeIndex(fromChainID)`)와
+  정확히 일치해야 합니다.
+- `v`, `r`, `s`의 길이가 각각 `args`와 같아야 하고, 한 항목 안에서 세 서명 배열의 길이가 서로 같아야 합니다.
+- 각 항목에서 **서명자 주소 오름차순**으로 집계되는 권한 있는 서명자가 `threshold()`명 이상이어야 합니다.
+  복원된 주소가 중복이거나, validator 역할이 없거나, 오름차순이 아니면 단순히 집계되지 않으므로 항상
+  서명자 주소로 정렬해 제출하세요. 형식이 깨진 서명은 호출을 revert시킵니다.
+- `msg.value`는 0이어야 합니다.
+
+서명 대상은 다음 EIP-712 구조체입니다.
+
+```
+FinalizeBridge(uint256 fromChainID,uint256 index,address toToken,address to,uint256 value,bytes extraData)
+```
+
+도메인은 name `Validator`, version `1.0.0`, 목적지 체인 ID, `verifyingContract`는 목적지 브리지 주소이며
+(`domainSeparator()`로 조회 가능), 따라서 서명을 다른 목적지 체인 ID나 다른 검증 컨트랙트에 재사용할 수 없습니다.
+
+한 항목이라도 위 조건을 만족하지 못하면 **배치 전체가 revert**됩니다.
+
+검증은 통과했지만 금액 한도에 걸리거나, **인지된** 방식으로 지급이 실패한 항목(수신자 호출·ERC20 전송·발행이
+실패를 보고한 경우)은 접수된 뒤 **보류**됩니다. 이는 정상적인 결과이지 배치 실패가 아닙니다. 반면 **예상치
+못한** 조건은 다릅니다. 예컨대 브리지의 네이티브 잔액 부족이나 회계 불일치는 보류를 만들지 않고 배치 전체를
+revert시키며, 기대 인덱스도 그대로 유지됩니다.
+
+### 4.5 보류된 전송과 `releasePending`
+
+서명 검증은 통과했지만 인지된 사유로 지급할 수 없는 정산은 소실되지 않고 **보류**됩니다. 주요 원인은 안전 한도
+(비정상적으로 큰 단일 전송, 또는 특정 시간창 내 과도한 누적 거래량), 토큰 정지, 지급을 거부하는 수신자입니다.
+
+`BridgePending` 이벤트가 사유를 담은 status와 함께 발생합니다.
+
+| Status | 의미 |
+|---|---|
+| `TokenPaused` | 해당 토큰의 입금(정산)이 정지됨 |
+| `VerificationAmountThresholdExceeded` | 단일 전송 금액 한도 초과 |
+| `PeriodTotalValueThresholdExceeded` | 시간창 누적 거래량 한도 초과 |
+| `TransferFailed` / `MintFailed` | 수신자에게 지급 실패 |
+| `CrossSupplyLimitExceeded` | Cross 체인 네이티브 공급 한도 초과 |
+| `TokenScoreOverflow` / `TokenCurrentVolumeOverflow` | 금액을 안전하게 평가할 수 없음 |
+
+```solidity
+function releasePending(uint remoteChainID, uint index) external;
+```
+
+`releasePending`은 **누구나** 호출할 수 있으며 지급을 재시도합니다. 다음 조건을 모두 만족하면 성공합니다.
+
+- 브리지가 정지 상태가 아니고, 해당 출발 체인 항목이 정지 상태가 아니며, 그 토큰의 입금(정산)이
+  정지되어 있지 않음
+- 보류 기록에 저장된 검토 지연이 만료됨(`delayExpiration`, `0`이면 지연 없음)
+- 지급 자체가 성공함
+
+단일 전송·시간창 금액 한도는 재시도 시 **다시 평가되지 않습니다** — 최초 접수 시점에 이미 평가되었기
+때문입니다. 단, Cross 체인의 네이티브 공급 한도는 **다시 확인**됩니다.
+
+결합 `extraData` 호출은 재시도 시 절대 재실행되지 않으며, 보류된 전송은 항상 단순 지급으로 처리됩니다.
+
+**권한 기반 해소.** `VERIFIER_ROLE`은 정지·지연·한도 검사를 우회해 보류된 전송을 강제 지급할 수 있고,
+지급 대상을 다른 주소로 변경할 수 있습니다(원래 수신자가 수령을 영구 거부할 때의 복구 경로).
+`ADMIN_ROLE`은 지급 없이 보류 기록을 제거할 수 있습니다. 이는 신뢰가 필요한 거버넌스 권한이며
+[§6](#6-보안과-신뢰-모델)에 정리되어 있습니다.
+
+보류된 전송은 `getPendingArguments(remoteChainID, index)`로 확인하고, 보류 중인 인덱스 목록은
+`allPendingIndex(remoteChainID)`로 조회합니다. 검토 지연은 24시간으로 초기화되지만 관리자가 변경할 수 있으므로,
+고정값으로 가정하지 말고 기록의 `delayExpiration`을 읽으세요.
+
+### 4.6 조회용 함수
+
+브리지 컨트랙트:
+
+| 함수 | 반환 |
+|---|---|
+| `allChainIDs()` | 이 브리지에 등록된 모든 상대 체인 ID |
+| `allTokenPairs(remoteChainID)` | 해당 체인의 모든 토큰 페어와 로컬 공급 회계 정보 |
+| `getTokenPair(remoteChainID, token)` | 페어 상세: 대응 토큰, origin 여부, 정지 여부, 잠김/발행 수량 |
+| `getNextInitiateIndex(remoteChainID)` | 다음 출발 전송에 부여될 인덱스 |
+| `getNextFinalizeIndex(remoteChainID)` | 해당 출발 체인에 대해 다음에 접수될 인덱스 |
+| `allPendingIndex(remoteChainID)` / `getPendingArguments(remoteChainID, index)` | 보류된 전송과 그 인자·status·`delayExpiration` |
+| `isTokenFinalizePaused(remoteChainID, token)` | 해당 토큰의 입금(정산) 정지 여부 |
+| `maxExtraDataLength()` | `extraData` 최대 길이(`0` = 무제한) |
+| `threshold()` / `domainSeparator()` | 멀티시그 임계값과 이 브리지의 EIP-712 도메인 구분자 |
+| `paused()` | 전체 정지 상태 |
+
+`BridgeVerifier`:
+
+| 함수 | 반환 |
+|---|---|
+| `calculateFee(chainID, token, value)` | `(minimumValue, networkFee, exFee)` |
+| `getTokenConfig(chainID, token)` | `(minimumValue, networkFee, 실효 exFeeRate)` |
+| `getTokenPrice(token)` | `(exist, price)`. `exist == false`이면 반환된 price는 실시간 가격이 아니라 설정된 대체 가격입니다. |
+| `getMinimumTokenValue()` | 달러 기준 하한값(가격 피드의 달러 정밀도 기준) |
+| `denominator()` | 수수료 요율 분모인 `10000` |
+
+전송을 끝까지 추적하려면 출발 체인의 `BridgeInitiated`에서 `index`를 얻고, 목적지 체인에서 같은
+`(fromChainID, index)`의 `BridgeFinalized` 또는 `BridgePending`을 관측하면 됩니다.
+
+추적 로직에서는 두 가지 식별자를 구분하세요.
+
+- **로그 식별자** — 이미 처리한 로그를 걸러내는 용도: (체인 ID, 트랜잭션 해시, 로그 인덱스).
+- **논리적 전송 식별자** — 두 체인을 대응시키는 용도: (체인 ID, 브리지 주소, **방향**, 상대 체인 ID, `index`).
+  상대 체인 ID는 `BridgeInitiated`에서는 `toChainID`, `BridgeFinalized` / `BridgePending`에서는
+  `fromChainID`입니다. 출금·입금 인덱스가 서로 독립적으로 증가하므로 하나의 브리지에서 같은
+  `(상대 체인 ID, index)` 조합이 양방향에 모두 존재할 수 있어, 방향을 반드시 포함해야 합니다.
+
+또한 로그는 되돌려질 수 있고 상태도 최종이 아니라는 점을 전제하세요. 전송을 완료로 표시하기 전에 연동에 필요한
+만큼의 확정(finality)을 기다리고, 체인 재구성으로 제거된 로그를 처리하며, `BridgePending`이 **종료 상태가
+아니라는** 점을 기억하세요. 같은 전송이 이후에 지급되면 `BridgeFinalized`, 지급 없이 제거되면
+`PendingRemoved`를 발생시킬 수 있습니다.
+
+### 4.7 체인별 및 부가 진입점
+
+**Cross 체인 — 네이티브 공급 한도.** 브리지가 지급할 수 있는 네이티브 CROSS 총량이 설정 가능한 한도로
+제한되며 `crossSupply()`, `crossSupplyLimit()`으로 조회할 수 있습니다. 한도를 넘기는 정산은
+`CrossSupplyLimitExceeded`로 보류됩니다. 이 한도는 자동 정산과 공개 재시도에 적용되며, 권한 기반 강제
+지급은 우회합니다.
+
+**BSC — 크로스체인 소각.**
+
+```solidity
+function burnCrossToDeadWallet(address deadWallet, uint amount, bool alreadyTransferred) external returns (bool);
+```
+
+`alreadyTransferred = false`이면 누구나 CROSS를 소각하고 Cross 체인 측 공급에 반영할 수 있습니다.
+조건: 브리지가 정지 상태가 아니고, `amount`가 0이 아니며, `deadWallet`이 사전 승인된 소각 주소 중 하나이고,
+호출자가 브리지에 설정된 CROSS 토큰 `amount` 만큼을 approve했어야 합니다.
+
+`alreadyTransferred = true`이면 BSC 쪽에서는 토큰 이전이 일어나지 않습니다. 이미 소각 주소로 보냈다는 사실을
+호출자가 단언하는 것이며, 개시 이벤트는 브리지 자신을 출발 주체로 하여 발생합니다. 이 경로는 `ADMIN_ROLE`
+전용입니다.
+
+**`permitBridgeTokenBatch` — 대행 진입점.**
+
+```solidity
+function permitBridgeTokenBatch(BridgeTokenArguments[] calldata args, PermitArguments[] calldata permitArgs) external payable;
+```
+
+사전 approve 대신 EIP-2612 permit 서명으로 전송을 시작합니다. 탈취된 permit으로 제3자가 전송 파라미터를
+주입하는 것을 막기 위해 `INITIATOR_ROLE` 보유자만 호출할 수 있습니다.
+
+| 구조체 | 필드 |
+|---|---|
+| `BridgeTokenArguments` | `toChainID`, `fromToken`, `from`, `to`, `value`, `networkFee`, `exFee`, `extraData` — 의미는 `bridgeToken` 인자와 같습니다. 단 **`from`은 무시됩니다**: 자금은 항상 `permitArgs.account`에서 출금됩니다. |
+| `PermitArguments` | `token`, `account`, `value`, `deadline`, `v`, `r`, `s` — **브리지**에 allowance를 부여하는 표준 EIP-2612 permit입니다. |
+
+조건: `args.length == permitArgs.length`이고, 각 항목에서 `permitArgs.token`이 `fromToken`과 같고, `to`가
+`permitArgs.account`와 같으며, permit이 유효하고 만료되지 않았고, `permitArgs.value`가 `value` + 실행 시점
+재계산 수수료를 충족해야 합니다. 각 페어가 등록·활성 상태여야 합니다. `permitArgs.value`가 브리지의
+allowance가 되므로 소모되지 않은 부분은 승인 상태로 남습니다.
+
+[4.1](#41-bridgetoken--전송-시작)의 정지·등록·최소 금액·수수료·wrapped 발행량·`extraData` 조건이 항목마다
+공통으로 적용됩니다. 이 진입점은 EIP-2612 permit을 호환되게 구현한 ERC20 토큰만 지원하며, 네이티브 코인
+예약 주소는 사용할 수 없습니다. 배치는 **원자적**입니다 — 한 항목이 실패하면 모든 항목이 revert됩니다.
+이 호출에는 절대 value를 보내지 마세요. 비어 있지 않은 배치는 `msg.value == 0`을 요구하며, 빈 배치와 함께
+보낸 value는 브리지에 그대로 남습니다.
+
+**`SwapBridgeRouter` — 스왑과 브리지를 한 트랜잭션에.**
+
+Uniswap V3 시장에서 스왑한 뒤 그 결과로 즉시 브리지 전송을 시작하는 선택적 보조 컨트랙트입니다.
+8개의 진입점은 exact-input/exact-output, 단일 풀/멀티홉 경로, ERC20/네이티브 입력의 조합이며, 모든 진입점은
+params 구조체와 `deadline`을 받습니다.
+
+| 진입점 | 경로 형태 | 입력 | 필요한 `msg.value` |
+|---|---|---|---|
+| `swapBridgeExactInputSingle` | 단일 풀 | ERC20 | `0` |
+| `swapBridgeExactInput` | 멀티홉 `path` | ERC20 | `0` |
+| `swapBridgeExactOutputSingle` | 단일 풀 | ERC20 | `0` |
+| `swapBridgeExactOutput` | 멀티홉 `path` | ERC20 | `0` |
+| `swapBridgeExactInputSingleETH`, `swapBridgeExactInputETH` | 위와 동일 | 네이티브 코인 | `amountIn`과 정확히 일치 |
+| `swapBridgeExactOutputSingleETH`, `swapBridgeExactOutputETH` | 위와 동일 | 네이티브 코인 | `amountInMaximum` 이상 |
+
+파라미터:
+
+| 필드 | 사용 | 의미 |
+|---|---|---|
+| `tokenIn`, `tokenOut` | 단일 풀 변형 | 입력·출력 토큰. ETH 변형에서 `tokenIn`은 래핑된 네이티브 토큰이어야 합니다. |
+| `fee` | 단일 풀 변형 | 사용할 풀을 지정하는 Uniswap V3 수수료 계층. |
+| `path` | 멀티홉 변형 | 인코딩된 스왑 경로. exact-input은 입력 → 출력, exact-output은 **역순**(출력 → 입력)입니다. |
+| `amountIn` | exact-input | 공급하는 입력 금액. `sqrtPriceLimitX96`으로 스왑이 조기 종료되면 잔여분이 환불되므로, 반드시 전액이 소비되는 값은 아닙니다. |
+| `amountOutMinimum` | exact-input | 브리지 수수료 차감 전 스왑 결과에 대한 슬리피지 하한. |
+| `amountOut` | exact-output | **목적지 체인에서** 브리지 수수료 차감 후 정확히 수령할 금액. |
+| `amountInMaximum` | exact-output | 수용하는 최대 입력 금액. 사용되지 않은 부분은 환불됩니다. |
+| `sqrtPriceLimitX96` | 단일 풀 변형 | 스왑의 Uniswap V3 가격 한계. 제한 없음은 `0`. |
+| `bridgeParams.toChainID` | 전체 | 목적지 체인 ID. |
+| `bridgeParams.recipient` | 전체 | 목적지 체인의 수신자. |
+| `bridgeParams.extraData` | 전체 | 브리지로 전달되며 [4.3](#43-extradata--전송과-동시에-호출)의 규칙을 따릅니다. |
+| `deadline` | 전체 | 이 시각을 지나면 호출이 revert됩니다. |
+
+공통 규칙:
+
+- ERC20 변형: 라우터에 `amountIn`(exact-input) 또는 `amountInMaximum`(exact-output)을 approve하고 value는
+  보내지 않습니다.
+- 사용되지 않은 입력은 호출자에게 환불됩니다 — exact-output의 `amountInMaximum` 미사용분과 exact-input의
+  잔여분이며, 입력 토큰으로 또는 ETH 변형에서는 네이티브 코인으로 반환됩니다. exact-output ETH 변형에서는
+  `amountInMaximum`을 초과해 보낸 `msg.value`도 함께 환불됩니다.
+- 브리지 수수료는 스왑 결과에서 차감됩니다. 목적지 체인에서 수령하는 금액은 `SwapBridge` 이벤트의
+  `bridgeValue`이며, 같은 이벤트의 `initiateIndex`가 브리지 전송 인덱스이므로
+  [4.6](#46-조회용-함수)과 같이 추적하면 됩니다.
+- 구조체 선언은 `src/interface/ISwapBridgeRouter.sol`에 있습니다.
+
+사전 조회 함수:
+
+| 함수 | 입력 | 반환 |
+|---|---|---|
+| `getAmountSwapBridgeOut(toChainID, tokenIn, tokenOut, fee, amountIn)` | 입력 금액, 단일 풀 | `status`, `swapAmountOut`, `bridgeValue`, `networkFee`, `exFee` |
+| `getAmountSwapBridgeOutMultihop(toChainID, path, amountIn)` | 입력 금액, 멀티홉 | 위와 동일 |
+| `getAmountSwapBridgeIn(toChainID, tokenIn, tokenOut, fee, bridgeValue)` | 목표 목적지 수령액, 단일 풀 | `status`, `amountIn`, `swapAmountOut`, `networkFee`, `exFee` |
+| `getAmountSwapBridgeInMultihop(toChainID, path, bridgeValue)` | 목표 목적지 수령액, 멀티홉 | 위와 동일 |
+| `getExpectedBridgeAmount(toChainID, token, totalAmount)` | 수수료 차감 전 금액 | `status`, `bridgeValue`, `networkFee`, `exFee` |
+| `calculateBridgeFees(toChainID, token, value)` | 목적지 수령액 | `minimumValue`, `networkFee`, `exFee` |
+
+`status`는 `QuoteStatus`입니다. `Success`(1)만 사용 가능하며, `NoPair`(2)는 해당 체인에 토큰 페어가 등록되지
+않음, `InsufficientForFee`(3)는 금액이 네트워크 수수료를 감당하지 못함, `InsufficientValue`(4)는 결과 브리지
+금액이 최소값 미달, `InvalidSwap`(5)는 스왑 견적 실패(풀 없음 또는 유동성 부족), `Invalid`(0)은 초기화되지 않은
+기본값입니다.
+
+`getAmountSwapBridge*` 네 함수는 Uniswap quoter로 스왑을 시뮬레이션하므로 `view`가 **아닙니다** — 오프체인에서
+호출하세요. `getExpectedBridgeAmount`와 `calculateBridgeFees`는 `view`입니다.
+
+---
+
+## 5. Validator 네트워크
+
+이 컨트랙트들의 오프체인 상대측은 독립적인 validator 네트워크
+([`bridge-validator`](https://github.com/to-nexus/bridge-validator))입니다. 담당 역할은 다음과 같습니다.
+
+| 역할 | 설명 |
+|---|---|
+| **관측** | 각 validator가 등록된 모든 체인의 브리지 컨트랙트를 독립적으로 감시하며, 해당 체인에 설정된 확정(confirmation/finality) 정책을 만족한 이벤트만 처리합니다. |
+| **서명(attestation)** | 관측한 전송마다 목적지 브리지 도메인에 바인딩된 EIP-712 메시지에 서명합니다. 하나의 서명은 체인쌍·인덱스·토큰·수신자·수량·`extraData`가 특정된 단 하나의 전송만을 증명합니다. |
+| **조율** | validator들은 서로를 직접 호출하지 않습니다. 복제된 공유 조율 클러스터(etcd)에 서명을 게시하며, 이 클러스터가 노드 중 단일 리더를 선출합니다. |
+| **제출** | 선출된 리더가 전송 인덱스 순서대로, 해당 전송의 서명이 임계값을 충족한 뒤에 정산 트랜잭션을 제출합니다. 제출을 한 노드로 모으면 중복·경합 정산 트랜잭션을 피할 수 있습니다. |
+
+이 설계에서 따라오는 성질과 그 한계:
+
+- **정산에는 정족수가 필요합니다.** 서명은 복원된 서명자가 현재 온체인 validator 역할을 보유한 경우에만
+  집계되며, 정산에는 서로 다른 서명자 `threshold`명이 필요합니다. 설정된 임계값이 `1`인 경우를 제외하면
+  validator 한 곳이 단독으로 지급을 승인할 수 없습니다 — 실제 값은 `threshold()`로 확인하세요.
+- **validator는 사용자 자금을 보관하지 않습니다.** 서명만 생성하며, 자산은 브리지 컨트랙트가 보관합니다.
+- **저하되는 것은 가용성이지 자산 보관이 아닙니다.** 참여 validator가 `threshold`보다 적으면 정산이 멈추고,
+  참여가 회복되면 다음 기대 인덱스부터 재개됩니다. 예치 내역은 온체인에 그대로 기록되어 있습니다.
+- **권한 회수는 온체인에서 효력을 가집니다.** 어떤 주소에서 validator 역할을 제거하면 이후 정산에서
+  그 주소의 서명은 무효가 됩니다.
+- **거버넌스는 신뢰 대상입니다.** validator 집합, 임계값, 컨트랙트 업그레이드, 한도는 validator 정족수가
+  아니라 관리 역할이 통제합니다 — [§6](#6-보안과-신뢰-모델), [§8](#8-역할) 참고.
+
+배포 구성, 조율 저장소 구조, 타이밍·재시도 정책, 키 관리 등 네트워크의 운영 세부 사항은 이 문서의
+범위에 포함하지 않습니다.
+
+---
+
+## 6. 보안과 신뢰 모델
+
+| 장치 | 효과 |
+|---|---|
+| 임계값 멀티시그 | 정산에는 정산 대상 전송에 대한 권한 있는 서로 다른 validator 서명 `threshold`개가 필요합니다. |
+| EIP-712 도메인 바인딩 | 서명이 목적지 체인 ID와 브리지 주소에 묶이므로, 다른 목적지 체인 ID나 다른 검증 컨트랙트에 재사용할 수 없습니다. |
+| 순차 인덱스 | 출발 체인의 각 전송은 최대 한 번만, 인덱스 순서로만 접수됩니다. 보류된 전송도 인덱스를 소비하므로 그 지급은 이후 전송보다 늦게 완료될 수 있습니다. |
+| 로컬 공급 회계 | 각 브리지가 잠김(origin)·발행(wrapped) 수량을 추적하고, wrapped 출금은 브리지의 로컬 발행 회계를 초과할 수 없습니다. 체인 간 1:1 관계는 증명(서명)이 유효하고 wrapped `MINTER_ROLE`이 브리지로만 제한되어 있는 한 유지됩니다. |
+| 금액 한도 | 단일 전송·시간창 누적 한도를 두어 비정상적으로 큰 흐름은 자동 지급 대신 보류로 우회시킵니다. |
+| 네이티브 공급 한도 | Cross 체인에서 네이티브 코인의 자동 지급과 공개 재시도가 조정 가능한 한도로 제한됩니다. |
+| 다계층 정지 | 전체·체인별·토큰별로 전송을 중단할 수 있고, 출금 방향과 입금 방향을 독립적으로 제어합니다. |
+| 안전한 지급 | 인지된 지급 실패(수신자 호출·ERC20 전송·발행이 실패를 보고한 경우)와 결합 호출 실패는 단순 지급 또는 보류로 격하되며 자금을 잃지 않습니다. 예상치 못한 조건은 보류를 만들지 않고 정산을 revert시킵니다. |
+| 결합 호출 화이트리스트 | `extraData`는 `BridgeExecutor` 관리자가 명시적으로 등록한 대상만 호출할 수 있고, 특정 함수 selector로 제한할 수 있습니다. |
+| 재진입 방지 | 전송 시작, 배치 정산, 보류 지급, 결합 호출 실행 경로가 재진입 보호를 받습니다. |
+
+**신뢰가 필요한 권한.** 사용자는 다음을 위험 모델의 일부로 간주해야 합니다.
+
+- `DEFAULT_ADMIN_ROLE`은 validator 역할을 포함한 모든 역할을 부여·회수하므로, 최종적으로 누가 정산을
+  승인할 수 있는지를 통제합니다.
+- 브리지의 `ADMIN_ROLE`은 브리지 구현 업그레이드(UUPS), 서명 임계값 변경, 검토 지연 재설정,
+  수수료/한도 및 executor 구성요소 교체, 지급 없이 보류 기록 제거를 수행할 수 있습니다.
+- `BridgeVerifier`와 `BridgeExecutor`의 `ADMIN_ROLE`은 브리지와 독립적인 구성원 집합으로, 각각 금액 한도와
+  가격 피드 참조, 결합 호출 화이트리스트를 통제합니다.
+- `VERIFIER_ROLE`은 정지·지연·한도 검사를 우회해 보류된 전송을 강제 지급하고, 지급 대상을 다른 주소로
+  변경할 수 있습니다.
+- `OPERATOR_ROLE`은 전체·체인별·토큰별로 전송을 정지할 수 있습니다.
+- `PRICER_ROLE`은 수수료와 금액 한도의 기준이 되는 가격을 게시합니다.
+- 각 `CrossMintableERC20V2` wrapped 토큰은 **자체** 기본 관리자를 가지며, 브리지의 역할과 무관하게 그 토큰의
+  `MINTER_ROLE`을 통제합니다. (이전 버전 `CrossMintableERC20`에는 그런 관리자가 없고, 불변 브리지 주소가
+  유일한 발행자입니다.)
+
+---
+
+## 7. 컨트랙트
+
+| 컨트랙트 | 역할 |
+|---|---|
+| `BaseBridge` | 브리지 핵심: 전송 시작, 서명 검증 정산, 보류 처리, 레지스트리와 권한. 업그레이더블(UUPS). |
+| `CrossBridge` | Cross 체인 배포본. 네이티브 CROSS 공급 한도를 추가합니다. |
+| `BSCBridge` / `BSCBridgeV2` | BSC 배포본. V2는 크로스체인 소각 반영 기능을 추가합니다. |
+| `BridgeVerifier` | 수수료 조회와 금액 한도 평가. |
+| `BridgeExecutor` | 정산 시 화이트리스트된 `extraData` 호출을 실행합니다. |
+| `PriceFeed` | 수수료·한도 계산에 사용되는 토큰/네이티브 가격 소스. 업그레이더블(UUPS). |
+| `CrossMintableERC20V2` | 브리지가 발행하는 wrapped 토큰(`ERC20` + `ERC20Permit`). |
+| `SwapBridgeRouter` | 선택적 스왑 + 브리지 라우터(Uniswap V3). |
+| `BridgeBot` | 주기적 반복 전송을 위한 선택적 보조 컨트랙트. |
+
+보조 모듈: `abstract/RoleManager`(접근 제어), `abstract/ValidatorManager`(EIP-712 도메인과 임계값 검증),
+`abstract/BridgeRegistry`(체인·토큰 페어·인덱스·보류 기록), `lib/`(상수, 금액 환산).
+
+---
+
+## 8. 역할
+
+접근 제어는 역할 기반이며, 역할은 **보호된 함수를 노출하는 컨트랙트 단위로 범위가 정해집니다.**
+`BaseBridge`, `BridgeVerifier`, `PriceFeed`, `BridgeExecutor`, 각 wrapped 토큰은 서로 독립적인 접근 제어
+상태를 가지므로, 두 컨트랙트의 같은 역할 이름은 서로 다른 구성원 집합입니다. 각 컨트랙트는 자체 관리자를
+가지며, 브리지의 관리자가 다른 컨트랙트를 통제하지는 않습니다.
+
+구성원 열거는 모든 컨트랙트에서 제공되지 않습니다. `getRoleMembers(role)`는 브리지, `PriceFeed`,
+`BridgeVerifier`에 존재하지만, `BridgeExecutor`와 `CrossMintableERC20V2`는 `hasRole`과
+`RoleGranted` / `RoleRevoked` 이벤트만 제공하므로 전체 구성원은 이벤트 이력으로 재구성해야 합니다.
+
+| 역할 | 컨트랙트 | 권한 |
+|---|---|---|
+| `DEFAULT_ADMIN_ROLE` | 브리지 | 아래 모든 브리지 역할(`VALIDATOR_ROLE` 포함)을 부여·회수. 초기화 시 배포 소유자에게 부여됩니다. |
+| `ADMIN_ROLE` | 브리지 | 컨트랙트 업그레이드, 임계값 변경, 구성요소 연결, 검토 지연 설정, 보류 기록 제거 |
+| | Verifier | 금액 한도·시간창 설정, 정산 가스 가정값, 가격 피드 교체 |
+| | Executor | 대상/selector 화이트리스트, 반환 데이터 크기 제한, 잔류 자산 회수 |
+| `VALIDATOR_ROLE` | 브리지 | 정산 임계값에 집계되는 서명 |
+| `OPERATOR_ROLE` | 브리지 | 전체·체인별·토큰별 정지 |
+| `EDITOR_ROLE` | 브리지 | 토큰 페어 등록, `extraData` 길이 제한 |
+| | Verifier | 교환 수수료 요율, 기본 가격, 최소 전송 금액 |
+| `VERIFIER_ROLE` | 브리지 | 보류 전송 강제 지급, 지급 대상 변경, 검토 기간 조정 |
+| `PRICER_ROLE` | PriceFeed | 토큰·네이티브 코인 가격 게시 |
+| | Verifier | 목적지 체인 가스 가격 게시 |
+| `INITIATOR_ROLE` | 브리지 | permit 기반 배치 전송 제출 |
+| `EXECUTOR_ROLE` | Executor | 결합 `extraData` 호출 실행 — 브리지가 보유 |
+| `MINTER_ROLE` | wrapped 토큰 | 발행·소각. 생성 시 브리지에 부여되며, `CrossMintableERC20V2`에서는 해당 토큰 자체의 기본 관리자가 관리 |
+
+---
+
+## 9. 이벤트
+
+| 이벤트 | 발생 시점 |
+|---|---|
+| `BridgeInitiated` | 출발 체인에서 전송이 시작될 때(전송 `index`와 징수된 수수료 포함) |
+| `BridgeFinalized` | 목적지 체인에서 지급이 완료될 때 |
+| `BridgePending` | 전송이 보류될 때(사유 status 포함) |
+| `ExtraCallExecuted` | 결합 `extraData` 호출이 시도되어 성공 또는 실패로 종료될 때 |
+| `ManualReleased` / `PendingRemoved` / `VerificationDelayExpirationSet` | 보류 전송이 강제 해소·제거되거나 검토 기간이 변경될 때 |
+| `ThresholdChanged` | 멀티시그 임계값이 변경될 때 |
+| `TokenPairRegistered` / `TokenPauseSet` / `ChainPauseSet` | 레지스트리나 이용 가능 상태가 변경될 때 |
+| `PriceUpdated` / `NativeTokenPriceUpdated` / `GasPriceUpdated` / `ExchangeFeeUpdated` | 가격·수수료 설정이 변경될 때 |
+
+---
+
+## 10. 빌드와 테스트
+
+[Foundry](https://book.getfoundry.sh/) 기반이며, 의존성은 git submodule로 관리됩니다.
+
+```bash
+git submodule update --init --recursive
+forge build
+forge test
+forge test --match-contract BridgeExecutorTest -vvv
+forge test --gas-report
+forge fmt
+```
+
+참고:
+
+- 기본 프로필은 IR 파이프라인으로 컴파일합니다. 느리지만 컨트랙트 크기 한도를 맞추기 위한 설정입니다.
+- BSC V2 브리지용 별도 프로필이 있습니다: `FOUNDRY_PROFILE=v2 forge build`
+- import 경로는 `remappings.txt`로 해석됩니다.
+
+테스트는 왕복 전송, 레지스트리·권한 동작, revert 및 보류 경계 조건, 결합 `extraData` 실행과 폴백,
+금액 한도 감시, 네이티브 공급 한도, 서명·임계값 검증, wrapped 토큰, 스왑 라우터, 가스 측정을 포함합니다.
+
+---
+
+## 11. Go 바인딩
+
+`binding/go`에는 별도 모듈로 배포되는 생성된 Go 바인딩(`abigen`)이 있습니다.
+
+```
+module github.com/to-nexus/bridge-contracts/binding/go
+
+import "github.com/to-nexus/bridge-contracts/binding/go/src"   // package binding
+```
+
+validator 네트워크가 사용하는 연동 지점이며, 브리지 ABI와 이벤트에 타입 안전하게 접근해야 하는 Go
+클라이언트라면 가져다 쓸 수 있습니다. 컨트랙트 생성자, `BaseBridgeBridgeInitiated` 같은 타입화된 이벤트
+구조체, 로그 필터러/파서를 제공합니다. 생성 산출물이므로 컨트랙트 ABI가 변경되면 재생성되며, 연동 대상
+배포본과 일치하는 버전으로 고정해 사용하세요.
+
+---
+
+## 12. 라이선스
+
+MIT


### PR DESCRIPTION
## Summary

기존 Foundry 템플릿 README를 폐기하고, **외부 독자(통합 개발자 · 일반 유저 · 감사자 · 토큰 프로젝트 · Go 클라이언트)** 를 대상으로 브리지의 설계와 실제 동작 방식을 정리했습니다.

- `README.md` — 영문
- `README_KO.md` — 한글 미러 (두 문서는 상단에서 서로 링크)

## 문서 구성

| 장 | 내용 |
|---|---|
| 1–2 | 개요와 전송 흐름 (구성도 + 시퀀스 다이어그램) |
| 3 | 토큰 모델 — origin/wrapped, lock&mint / burn&release, 토큰 호환성 가정 |
| 4 | 사용자 API — `bridgeToken` 인자·조건·지불 방식, 수수료 사전 조회, `extraData` 결합 호출, `finalizeBridgeBatch`, 보류 전송과 `releasePending`, 조회 함수, 체인별·부가 진입점(permit 배치 / BSC 소각 / SwapBridgeRouter) |
| 5 | Validator 네트워크 — 역할과 추상 흐름 |
| 6 | 보안 · 신뢰 모델 (신뢰가 필요한 권한 포함) |
| 7–9 | 컨트랙트 목록, 역할 권한(컨트랙트 범위별), 이벤트 |
| 10–12 | 빌드·테스트, Go 바인딩, 라이선스 |

## 검토

GPT-5.6-sol 외부 리뷰 **6라운드**를 거쳐 모든 지적을 소스 코드로 재확인 후 반영, 최종 `approved: true`(highest_severity: low)를 받았습니다. 검토 과정에서 발견해 정정한 주요 사실:

- **수수료 인자는 상한 선언일 뿐, 컨트랙트는 실행 시점에 재계산한 금액을 징수** — 네이티브 전송은 `msg.value == value + 재계산 수수료` 정확히 일치해야 하며, 여유분을 더하면 revert됩니다. ERC20은 상한으로 approve할 경우 잔여 allowance가 남습니다.
- `releasePending`은 단일/시간창 금액 한도를 **재평가하지 않음** (Cross 네이티브 공급 한도만 재확인)
- `VERIFIER_ROLE`의 강제 지급·수신자 변경, `ADMIN_ROLE`의 지급 없는 보류 제거를 신뢰 권한으로 명시
- 인지된 지급 실패는 보류, **예상치 못한 실패는 배치 전체 revert**
- wrapped 토큰 `MINTER_ROLE`은 토큰 자체 관리자가 통제(V2) / 불변 브리지 고정(구버전) — 별도 신뢰 경계
- fee-on-transfer·rebasing 토큰은 명목 금액만 기록되므로 미지원
- 라우터: exact-input ETH는 `msg.value == amountIn`, exact-output ETH는 `>= amountInMaximum`
- 이벤트 추적: 로그 식별자와 논리적 전송 식별자를 분리하고, `BridgePending`이 종료 상태가 아님을 명시

## 공개 범위

외부 문서이므로 다음은 의도적으로 제외했습니다: validator 조율 저장소 키 레이아웃·타이밍·재시도·failover·키 관리, 배포 스크립트·환경변수·배포 주소·체인 ID, storage gap 수치, 감사 티켓 번호.

## 확인

- 내부 앵커 링크 19개 전부 정상 (EN/KO)
- 코드 변경 없음 — 문서 2개만 변경
